### PR TITLE
refactor(state): segment useAppState into 4 domain hooks — v3.3.0

### DIFF
--- a/src/hooks/useAppState.ts
+++ b/src/hooks/useAppState.ts
@@ -1,133 +1,30 @@
-import { useState, useEffect, useRef } from 'react';
-import { SimilarityMatch } from '../utils/similarityUtils';
-import { LibraryAsset } from '../utils/libraryUtils';
-import { DEFAULT_TITLE, DEFAULT_TOPIC, DEFAULT_MOOD } from '../utils/songDefaults';
+/**
+ * useAppState — barrel re-export.
+ * Consumers continue to call useAppState() and destructure freely.
+ * Internal state is now managed by 4 domain hooks.
+ *
+ * @version 3.3.0
+ */
+import { useUIState } from './useUIState';
+import { useSongMeta } from './useSongMeta';
+import { useMusicalMeta } from './useMusicalMeta';
+import { useSessionState } from './useSessionState';
 
-/** Key used to track first-ever launch (splash shown once). */
-const SPLASH_SHOWN_KEY = 'vibe_splash_shown';
-
-/** Read splash guard synchronously so the initial state is correct before any render. */
-const shouldShowSplash = (): boolean => {
-  try {
-    if (localStorage.getItem(SPLASH_SHOWN_KEY)) return false;
-    localStorage.setItem(SPLASH_SHOWN_KEY, '1');
-    return true;
-  } catch {
-    return false;
-  }
-};
+export { useUIState } from './useUIState';
+export { useSongMeta } from './useSongMeta';
+export { useMusicalMeta } from './useMusicalMeta';
+export { useSessionState } from './useSessionState';
 
 export function useAppState() {
-  const [title, setTitle] = useState(DEFAULT_TITLE);
-  const [titleOrigin, setTitleOrigin] = useState<'user' | 'ai'>('user');
-  const [topic, setTopic] = useState(DEFAULT_TOPIC);
-  const [mood, setMood] = useState(DEFAULT_MOOD);
-  const [rhymeScheme, setRhymeScheme] = useState('AABB');
-  const [targetSyllables, setTargetSyllables] = useState(10);
-  const [newSectionName, setNewSectionName] = useState('');
-  const [genre, setGenre] = useState('');
-  const [tempo, setTempo] = useState('120');
-  const [instrumentation, setInstrumentation] = useState('');
-  const [rhythm, setRhythm] = useState('');
-  const [narrative, setNarrative] = useState('');
-  const [musicalPrompt, setMusicalPrompt] = useState('');
-  const [theme, setTheme] = useState<'light' | 'dark'>('dark');
-  const [activeTab, setActiveTab] = useState<'lyrics' | 'musical'>('lyrics');
-  const [isStructureOpen, setIsStructureOpen] = useState(true);
-  const [isLeftPanelOpen, setIsLeftPanelOpen] = useState(false);
-  const [draggedItemIndex, setDraggedItemIndex] = useState<number | null>(null);
-  const [dragOverIndex, setDragOverIndex] = useState<number | null>(null);
-  const [draggedLineInfo, setDraggedLineInfo] = useState<{ sectionId: string; lineId: string } | null>(null);
-  const [dragOverLineInfo, setDragOverLineInfo] = useState<{ sectionId: string; lineId: string } | null>(null);
-  const [similarityMatches, setSimilarityMatches] = useState<SimilarityMatch[]>([]);
-  const [libraryCount, setLibraryCount] = useState(0);
-  const [libraryAssets, setLibraryAssets] = useState<LibraryAsset[]>([]);
-  const [isSavingToLibrary, setIsSavingToLibrary] = useState(false);
-  const [audioFeedback, setAudioFeedback] = useState(true);
-  const [isMarkupMode, setIsMarkupMode] = useState(false);
-  const [markupText, setMarkupText] = useState('');
-
-  // Splash shown exactly once — initialised synchronously to avoid double render
-  const [isAboutOpen, setIsAboutOpen] = useState<boolean>(() => shouldShowSplash());
-
-  const [isSettingsOpen, setIsSettingsOpen] = useState(false);
-  const [apiErrorModal, setApiErrorModal] = useState<{ open: boolean; message: string }>({ open: false, message: '' });
-  const [isImportModalOpen, setIsImportModalOpen] = useState(false);
-  const [isExportModalOpen, setIsExportModalOpen] = useState(false);
-  const [isSectionDropdownOpen, setIsSectionDropdownOpen] = useState(false);
-  const [isSimilarityModalOpen, setIsSimilarityModalOpen] = useState(false);
-  const [isSaveToLibraryModalOpen, setIsSaveToLibraryModalOpen] = useState(false);
-  const [isVersionsModalOpen, setIsVersionsModalOpen] = useState(false);
-  const [isResetModalOpen, setIsResetModalOpen] = useState(false);
-  const [shouldAutoGenerateTitle, setShouldAutoGenerateTitle] = useState(false);
-  const [confirmModal, setConfirmModal] = useState<{ open: boolean; onConfirm: () => void } | null>(null);
-  const [promptModal, setPromptModal] = useState<{ open: boolean; onConfirm: (value: string) => void } | null>(null);
-  const [isSessionHydrated, setIsSessionHydrated] = useState(false);
-  const [hasSavedSession, setHasSavedSession] = useState(false);
-  const [hasApiKey, setHasApiKey] = useState(true);
-
-  // Elevated from useLanguageAdapter — shared between useSongAnalysis and useSongComposer
-  const [songLanguage, setSongLanguage] = useState('');
-
-  const importInputRef = useRef<HTMLInputElement>(null);
-  const markupTextareaRef = useRef<HTMLTextAreaElement>(null);
-
-  // Theme class on <html>
-  useEffect(() => {
-    if (theme === 'dark') document.documentElement.classList.add('dark');
-    else document.documentElement.classList.remove('dark');
-  }, [theme]);
-
-  useEffect(() => {
-    const controller = new AbortController();
-    fetch('/api/status', { signal: controller.signal })
-      .then(r => r.json())
-      .then((data: { available?: boolean }) => setHasApiKey(data.available === true))
-      .catch((err) => { if (err.name !== 'AbortError') setHasApiKey(false); });
-    return () => controller.abort();
-  }, []);
-
-  useEffect(() => {
-    const handler = (e: Event) => {
-      const detail = (e as CustomEvent<{ message: string }>).detail;
-      setApiErrorModal({ open: true, message: detail.message });
-    };
-    window.addEventListener('vibe:apierror', handler);
-    return () => window.removeEventListener('vibe:apierror', handler);
-  }, []);
+  const ui = useUIState();
+  const meta = useSongMeta();
+  const musical = useMusicalMeta();
+  const session = useSessionState();
 
   return {
-    title, setTitle, titleOrigin, setTitleOrigin,
-    topic, setTopic, mood, setMood,
-    rhymeScheme, setRhymeScheme, targetSyllables, setTargetSyllables,
-    newSectionName, setNewSectionName,
-    genre, setGenre, tempo, setTempo,
-    instrumentation, setInstrumentation, rhythm, setRhythm,
-    narrative, setNarrative, musicalPrompt, setMusicalPrompt,
-    theme, setTheme, activeTab, setActiveTab,
-    isStructureOpen, setIsStructureOpen, isLeftPanelOpen, setIsLeftPanelOpen,
-    draggedItemIndex, setDraggedItemIndex, dragOverIndex, setDragOverIndex,
-    draggedLineInfo, setDraggedLineInfo, dragOverLineInfo, setDragOverLineInfo,
-    similarityMatches, setSimilarityMatches, libraryCount, setLibraryCount,
-    libraryAssets, setLibraryAssets, isSavingToLibrary, setIsSavingToLibrary,
-    audioFeedback, setAudioFeedback,
-    isMarkupMode, setIsMarkupMode, markupText, setMarkupText,
-    isAboutOpen, setIsAboutOpen,
-    isSettingsOpen, setIsSettingsOpen,
-    apiErrorModal, setApiErrorModal,
-    isImportModalOpen, setIsImportModalOpen,
-    isExportModalOpen, setIsExportModalOpen,
-    isSectionDropdownOpen, setIsSectionDropdownOpen,
-    isSimilarityModalOpen, setIsSimilarityModalOpen,
-    isSaveToLibraryModalOpen, setIsSaveToLibraryModalOpen,
-    isVersionsModalOpen, setIsVersionsModalOpen,
-    isResetModalOpen, setIsResetModalOpen,
-    shouldAutoGenerateTitle, setShouldAutoGenerateTitle,
-    confirmModal, setConfirmModal, promptModal, setPromptModal,
-    hasSavedSession, setHasSavedSession,
-    isSessionHydrated, setIsSessionHydrated,
-    hasApiKey,
-    songLanguage, setSongLanguage,
-    importInputRef, markupTextareaRef,
+    ...ui,
+    ...meta,
+    ...musical,
+    ...session,
   };
 }

--- a/src/hooks/useMusicalMeta.ts
+++ b/src/hooks/useMusicalMeta.ts
@@ -1,0 +1,19 @@
+import { useState } from 'react';
+
+export function useMusicalMeta() {
+  const [genre, setGenre] = useState('');
+  const [tempo, setTempo] = useState('120');
+  const [instrumentation, setInstrumentation] = useState('');
+  const [rhythm, setRhythm] = useState('');
+  const [narrative, setNarrative] = useState('');
+  const [musicalPrompt, setMusicalPrompt] = useState('');
+
+  return {
+    genre, setGenre,
+    tempo, setTempo,
+    instrumentation, setInstrumentation,
+    rhythm, setRhythm,
+    narrative, setNarrative,
+    musicalPrompt, setMusicalPrompt,
+  };
+}

--- a/src/hooks/useSessionState.ts
+++ b/src/hooks/useSessionState.ts
@@ -1,0 +1,60 @@
+import { useState, useEffect } from 'react';
+import { SimilarityMatch } from '../utils/similarityUtils';
+import { LibraryAsset } from '../utils/libraryUtils';
+
+export function useSessionState() {
+  // ── Theme ─────────────────────────────────────────────────────────────────
+  const [theme, setTheme] = useState<'light' | 'dark'>('dark');
+
+  // ── API / session ─────────────────────────────────────────────────────────
+  const [hasApiKey, setHasApiKey] = useState(true);
+  const [isSessionHydrated, setIsSessionHydrated] = useState(false);
+  const [hasSavedSession, setHasSavedSession] = useState(false);
+
+  // ── Audio ─────────────────────────────────────────────────────────────────
+  const [audioFeedback, setAudioFeedback] = useState(true);
+
+  // ── Drag state ────────────────────────────────────────────────────────────
+  const [draggedItemIndex, setDraggedItemIndex] = useState<number | null>(null);
+  const [dragOverIndex, setDragOverIndex] = useState<number | null>(null);
+  const [draggedLineInfo, setDraggedLineInfo] = useState<{ sectionId: string; lineId: string } | null>(null);
+  const [dragOverLineInfo, setDragOverLineInfo] = useState<{ sectionId: string; lineId: string } | null>(null);
+
+  // ── Library / similarity ──────────────────────────────────────────────────
+  const [similarityMatches, setSimilarityMatches] = useState<SimilarityMatch[]>([]);
+  const [libraryCount, setLibraryCount] = useState(0);
+  const [libraryAssets, setLibraryAssets] = useState<LibraryAsset[]>([]);
+  const [isSavingToLibrary, setIsSavingToLibrary] = useState(false);
+
+  // ── Theme class on <html> ─────────────────────────────────────────────────
+  useEffect(() => {
+    if (theme === 'dark') document.documentElement.classList.add('dark');
+    else document.documentElement.classList.remove('dark');
+  }, [theme]);
+
+  // ── API key status check ──────────────────────────────────────────────────
+  useEffect(() => {
+    const controller = new AbortController();
+    fetch('/api/status', { signal: controller.signal })
+      .then(r => r.json())
+      .then((data: { available?: boolean }) => setHasApiKey(data.available === true))
+      .catch((err) => { if (err.name !== 'AbortError') setHasApiKey(false); });
+    return () => controller.abort();
+  }, []);
+
+  return {
+    theme, setTheme,
+    hasApiKey,
+    isSessionHydrated, setIsSessionHydrated,
+    hasSavedSession, setHasSavedSession,
+    audioFeedback, setAudioFeedback,
+    draggedItemIndex, setDraggedItemIndex,
+    dragOverIndex, setDragOverIndex,
+    draggedLineInfo, setDraggedLineInfo,
+    dragOverLineInfo, setDragOverLineInfo,
+    similarityMatches, setSimilarityMatches,
+    libraryCount, setLibraryCount,
+    libraryAssets, setLibraryAssets,
+    isSavingToLibrary, setIsSavingToLibrary,
+  };
+}

--- a/src/hooks/useSongMeta.ts
+++ b/src/hooks/useSongMeta.ts
@@ -1,0 +1,27 @@
+import { useState } from 'react';
+import { DEFAULT_TITLE, DEFAULT_TOPIC, DEFAULT_MOOD } from '../utils/songDefaults';
+
+export function useSongMeta() {
+  const [title, setTitle] = useState(DEFAULT_TITLE);
+  const [titleOrigin, setTitleOrigin] = useState<'user' | 'ai'>('user');
+  const [topic, setTopic] = useState(DEFAULT_TOPIC);
+  const [mood, setMood] = useState(DEFAULT_MOOD);
+  const [rhymeScheme, setRhymeScheme] = useState('AABB');
+  const [targetSyllables, setTargetSyllables] = useState(10);
+  const [newSectionName, setNewSectionName] = useState('');
+  const [shouldAutoGenerateTitle, setShouldAutoGenerateTitle] = useState(false);
+  // Elevated from useLanguageAdapter — shared between useSongAnalysis and useSongComposer
+  const [songLanguage, setSongLanguage] = useState('');
+
+  return {
+    title, setTitle,
+    titleOrigin, setTitleOrigin,
+    topic, setTopic,
+    mood, setMood,
+    rhymeScheme, setRhymeScheme,
+    targetSyllables, setTargetSyllables,
+    newSectionName, setNewSectionName,
+    shouldAutoGenerateTitle, setShouldAutoGenerateTitle,
+    songLanguage, setSongLanguage,
+  };
+}

--- a/src/hooks/useUIState.ts
+++ b/src/hooks/useUIState.ts
@@ -1,0 +1,74 @@
+import { useState, useRef, useEffect } from 'react';
+
+/** Splash guard — runs synchronously once to avoid double render. */
+const SPLASH_SHOWN_KEY = 'vibe_splash_shown';
+const shouldShowSplash = (): boolean => {
+  try {
+    if (localStorage.getItem(SPLASH_SHOWN_KEY)) return false;
+    localStorage.setItem(SPLASH_SHOWN_KEY, '1');
+    return true;
+  } catch {
+    return false;
+  }
+};
+
+export function useUIState() {
+  // ── Modals ────────────────────────────────────────────────────────────────
+  const [isAboutOpen, setIsAboutOpen] = useState<boolean>(() => shouldShowSplash());
+  const [isSettingsOpen, setIsSettingsOpen] = useState(false);
+  const [apiErrorModal, setApiErrorModal] = useState<{ open: boolean; message: string }>({ open: false, message: '' });
+  const [isImportModalOpen, setIsImportModalOpen] = useState(false);
+  const [isExportModalOpen, setIsExportModalOpen] = useState(false);
+  const [isSectionDropdownOpen, setIsSectionDropdownOpen] = useState(false);
+  const [isSimilarityModalOpen, setIsSimilarityModalOpen] = useState(false);
+  const [isSaveToLibraryModalOpen, setIsSaveToLibraryModalOpen] = useState(false);
+  const [isVersionsModalOpen, setIsVersionsModalOpen] = useState(false);
+  const [isResetModalOpen, setIsResetModalOpen] = useState(false);
+  const [confirmModal, setConfirmModal] = useState<{ open: boolean; onConfirm: () => void } | null>(null);
+  const [promptModal, setPromptModal] = useState<{ open: boolean; onConfirm: (value: string) => void } | null>(null);
+
+  // ── Navigation ────────────────────────────────────────────────────────────
+  const [activeTab, setActiveTab] = useState<'lyrics' | 'musical'>('lyrics');
+  const [isStructureOpen, setIsStructureOpen] = useState(true);
+  const [isLeftPanelOpen, setIsLeftPanelOpen] = useState(false);
+
+  // ── Markup editor ─────────────────────────────────────────────────────────
+  const [isMarkupMode, setIsMarkupMode] = useState(false);
+  const [markupText, setMarkupText] = useState('');
+  const markupTextareaRef = useRef<HTMLTextAreaElement>(null);
+
+  // ── Import ref ────────────────────────────────────────────────────────────
+  const importInputRef = useRef<HTMLInputElement>(null);
+
+  // ── vibe:apierror global event ────────────────────────────────────────────
+  useEffect(() => {
+    const handler = (e: Event) => {
+      const detail = (e as CustomEvent<{ message: string }>).detail;
+      setApiErrorModal({ open: true, message: detail.message });
+    };
+    window.addEventListener('vibe:apierror', handler);
+    return () => window.removeEventListener('vibe:apierror', handler);
+  }, []);
+
+  return {
+    isAboutOpen, setIsAboutOpen,
+    isSettingsOpen, setIsSettingsOpen,
+    apiErrorModal, setApiErrorModal,
+    isImportModalOpen, setIsImportModalOpen,
+    isExportModalOpen, setIsExportModalOpen,
+    isSectionDropdownOpen, setIsSectionDropdownOpen,
+    isSimilarityModalOpen, setIsSimilarityModalOpen,
+    isSaveToLibraryModalOpen, setIsSaveToLibraryModalOpen,
+    isVersionsModalOpen, setIsVersionsModalOpen,
+    isResetModalOpen, setIsResetModalOpen,
+    confirmModal, setConfirmModal,
+    promptModal, setPromptModal,
+    activeTab, setActiveTab,
+    isStructureOpen, setIsStructureOpen,
+    isLeftPanelOpen, setIsLeftPanelOpen,
+    isMarkupMode, setIsMarkupMode,
+    markupText, setMarkupText,
+    markupTextareaRef,
+    importInputRef,
+  };
+}


### PR DESCRIPTION
## Chantier 1 — Découplage de l'état global

### Problème
`useAppState.ts` exposait ~60 états/setters disparates dans un seul hook. Tout changement d'état modal déclenchait un re-render global sur `App.tsx`.

### Solution
Segmentation par domaine en 4 hooks spécialisés :

| Hook | Responsabilité | États clés |
|---|---|---|
| `useUIState` | Modales, panels, navigation, markup | `isAboutOpen`, `isSettingsOpen`, `apiErrorModal`, tous les `isXxxOpen`, `activeTab`, `isLeftPanelOpen`, `isStructureOpen`, markup state, refs |
| `useSongMeta` | Métadonnées éditoriales | `title`, `titleOrigin`, `topic`, `mood`, `rhymeScheme`, `targetSyllables`, `songLanguage` |
| `useMusicalMeta` | Paramètres musicaux | `genre`, `tempo`, `instrumentation`, `rhythm`, `narrative`, `musicalPrompt` |
| `useSessionState` | Runtime + persistance | `theme`, `hasApiKey`, `audioFeedback`, `isSessionHydrated`, `hasSavedSession`, drags, similarity, library |

### Migration des `useEffect`
- **`theme` → `document.classList`** : migré dans `useSessionState`
- **`/api/status` fetch** : migré dans `useSessionState`
- **`vibe:apierror` event listener** : migré dans `useUIState` (proximité logique avec `apiErrorModal`)

### Compat
`useAppState.ts` devient un barrel qui spread les 4 hooks — **zéro breaking change** sur tous les consommateurs existants (`App.tsx`, `useSessionPersistence`, etc.).

Les 4 hooks sont aussi exportés nommément pour une adoption progressive par les consommateurs futurs.

### Fichiers
- `src/hooks/useUIState.ts` — nouveau
- `src/hooks/useSongMeta.ts` — nouveau
- `src/hooks/useMusicalMeta.ts` — nouveau
- `src/hooks/useSessionState.ts` — nouveau
- `src/hooks/useAppState.ts` — refactorisé en barrel

### Checklist
- [ ] `npm run lint`
- [ ] `npm run test`
- [ ] Vérification manuelle : splash, thème, API key badge, ouverture modale

**Version cible : 3.3.0**