### PR TITLE
feat(3.3.3): useLanguageAdapter → types + pipeline + hook orchestrateur

### DIFF
--- a/src/hooks/analysis/languageAdapterPipeline.ts
+++ b/src/hooks/analysis/languageAdapterPipeline.ts
@@ -1,0 +1,95 @@
+// ---------------------------------------------------------------------------
+// Language Adapter – stateless async pipeline helpers
+// ---------------------------------------------------------------------------
+
+import { Type } from '@google/genai';
+import { AI_MODEL_NAME, getAi, safeJsonParse } from '../../utils/aiUtils';
+import type { Section } from '../../types';
+
+/**
+ * Reverse-translates adapted lyrics literally back to the source language.
+ * Used as the second step of the fidelity pipeline.
+ */
+export const reverseTranslate = async (
+  adaptedSong: Section[],
+  fromLanguage: string,
+  toLanguage: string,
+): Promise<string[]> => {
+  const lines = adaptedSong.flatMap(s =>
+    s.lines.filter(l => !l.isMeta).map(l => l.text)
+  );
+  if (lines.length === 0) return [];
+
+  const response = await getAi().models.generateContent({
+    model: AI_MODEL_NAME,
+    contents: [
+      `You are a professional literal translator. Translate the following ${fromLanguage} lyrics LITERALLY (word-for-word, no adaptation) into ${toLanguage}.`,
+      `Return a JSON array of strings, one translated string per input line, preserving order exactly.`,
+      `Input lines (${fromLanguage}):`,
+      JSON.stringify(lines),
+    ].join('\n'),
+    config: {
+      responseMimeType: 'application/json',
+      responseSchema: {
+        type: Type.ARRAY,
+        items: { type: Type.STRING },
+      },
+    },
+  });
+  return safeJsonParse<string[]>(response.text || '[]', []);
+};
+
+/**
+ * Reviews the fidelity of an adaptation via LLM scoring (0–100).
+ * Returns a score and an array of human-readable warnings.
+ */
+export const reviewFidelity = async (
+  originalSong: Section[],
+  reversedLines: string[],
+  targetLanguage: string,
+  sourceLang: string,
+): Promise<{ score: number; warnings: string[] }> => {
+  const originalLines = originalSong
+    .flatMap(s => s.lines.filter(l => !l.isMeta).map(l => l.text));
+
+  const reviewPrompt = [
+    `You are a senior lyric consultant reviewing the conceptual fidelity of a song adaptation from ${sourceLang} to ${targetLanguage}.`,
+    ``,
+    `You have:`,
+    `- ORIGINAL lyrics in ${sourceLang}`,
+    `- REVERSE TRANSLATION of the ${targetLanguage} adaptation (literal, back into ${sourceLang})`,
+    ``,
+    `Your task: assess whether the ${targetLanguage} adaptation preserved the conceptual intent of the original.`,
+    ``,
+    `Return a JSON object with:`,
+    `- "score": integer 0-100 (100 = perfect fidelity, 0 = completely lost the meaning)`,
+    `- "warnings": array of strings describing specific intent losses (empty array if none)`,
+    ``,
+    `ORIGINAL (${sourceLang}):`,
+    JSON.stringify(originalLines),
+    ``,
+    `REVERSE TRANSLATION (back to ${sourceLang}):`,
+    JSON.stringify(reversedLines),
+  ].join('\n');
+
+  const response = await getAi().models.generateContent({
+    model: AI_MODEL_NAME,
+    contents: reviewPrompt,
+    config: {
+      responseMimeType: 'application/json',
+      responseSchema: {
+        type: Type.OBJECT,
+        properties: {
+          score:    { type: Type.INTEGER },
+          warnings: { type: Type.ARRAY, items: { type: Type.STRING } },
+        },
+        required: ['score', 'warnings'],
+      },
+    },
+  });
+
+  return safeJsonParse<{ score: number; warnings: string[] }>(
+    response.text || '{"score":50,"warnings":[]}',
+    { score: 50, warnings: [] },
+  );
+};

--- a/src/hooks/analysis/languageAdapterTypes.ts
+++ b/src/hooks/analysis/languageAdapterTypes.ts
@@ -1,0 +1,49 @@
+// ---------------------------------------------------------------------------
+// Language Adapter – shared types
+// ---------------------------------------------------------------------------
+
+export type AdaptationStepId =
+  | 'idle'
+  | 'adapting'
+  | 'reversing'
+  | 'reviewing'
+  | 'done'
+  | 'failed';
+
+export interface AdaptationStep {
+  id: AdaptationStepId;
+  label: string;
+  /** 0–100, undefined while not yet started */
+  progress?: number;
+}
+
+export interface AdaptationProgress {
+  active: AdaptationStepId;
+  steps: AdaptationStep[];
+  /** Context label, e.g. "French → Baoulé" */
+  label: string;
+}
+
+export interface AdaptationResult {
+  /** Conceptual fidelity score 0–100 returned by the LLM reviewer */
+  score: number;
+  /** Human-readable warnings produced by the reviewer */
+  warnings: string[];
+  /** Whether the adapted lyrics were accepted (score >= 50) */
+  accepted: boolean;
+  /** Target language of this result */
+  targetLanguage: string;
+}
+
+export const PIPELINE_STEPS: AdaptationStep[] = [
+  { id: 'adapting',  label: 'Adapting lyrics'     },
+  { id: 'reversing', label: 'Reverse translating' },
+  { id: 'reviewing', label: 'Reviewing fidelity'  },
+  { id: 'done',      label: 'Done'                },
+];
+
+export const IDLE_PROGRESS: AdaptationProgress = {
+  active: 'idle',
+  steps: PIPELINE_STEPS,
+  label: '',
+};

--- a/src/hooks/analysis/useLanguageAdapter.ts
+++ b/src/hooks/analysis/useLanguageAdapter.ts
@@ -4,60 +4,22 @@ import { AI_MODEL_NAME, getAi, safeJsonParse } from '../../utils/aiUtils';
 import { mapSongWithPreservedIds, mergeAiSectionIntoCurrent } from '../../utils/songMergeUtils';
 import type { Section } from '../../types';
 import { makeSongUpdater } from '../hookUtils';
+import {
+  type AdaptationProgress,
+  type AdaptationResult,
+  type AdaptationStepId,
+  PIPELINE_STEPS,
+  IDLE_PROGRESS,
+} from './languageAdapterTypes';
+import { reverseTranslate, reviewFidelity } from './languageAdapterPipeline';
 
-// ---------------------------------------------------------------------------
-// Types
-// ---------------------------------------------------------------------------
-
-export type AdaptationStepId =
-  | 'idle'
-  | 'adapting'
-  | 'reversing'
-  | 'reviewing'
-  | 'done'
-  | 'failed';
-
-export interface AdaptationStep {
-  id: AdaptationStepId;
-  label: string;
-  /** 0–100, undefined while not yet started */
-  progress?: number;
-}
-
-export interface AdaptationProgress {
-  active: AdaptationStepId;
-  steps: AdaptationStep[];
-  /** Context label, e.g. "French → Baoulé" */
-  label: string;
-}
-
-export interface AdaptationResult {
-  /** Conceptual fidelity score 0–100 returned by the LLM reviewer */
-  score: number;
-  /** Human-readable warnings produced by the reviewer */
-  warnings: string[];
-  /** Whether the adapted lyrics were accepted (score >= 50) */
-  accepted: boolean;
-  /** Target language of this result */
-  targetLanguage: string;
-}
-
-// ---------------------------------------------------------------------------
-// Constants
-// ---------------------------------------------------------------------------
-
-const PIPELINE_STEPS: AdaptationStep[] = [
-  { id: 'adapting',  label: 'Adapting lyrics'       },
-  { id: 'reversing', label: 'Reverse translating'   },
-  { id: 'reviewing', label: 'Reviewing fidelity'    },
-  { id: 'done',      label: 'Done'                  },
-];
-
-const IDLE_PROGRESS: AdaptationProgress = {
-  active: 'idle',
-  steps: PIPELINE_STEPS,
-  label: '',
-};
+// Re-export types so consumers don't need to change their import paths.
+export type {
+  AdaptationStepId,
+  AdaptationStep,
+  AdaptationProgress,
+  AdaptationResult,
+} from './languageAdapterTypes';
 
 // ---------------------------------------------------------------------------
 // Hook params
@@ -106,13 +68,9 @@ export const useLanguageAdapter = ({
   const [adaptationProgress, setAdaptationProgress]   = useState<AdaptationProgress>(IDLE_PROGRESS);
   const [adaptationResult, setAdaptationResult]       = useState<AdaptationResult | null>(null);
 
-  // Track whether initial auto-detect has already been triggered
   const autoDetectFiredRef = useRef(false);
+  const firstSectionIdRef  = useRef<string | null>(null);
 
-  // Track the identity of the first section to detect song replacement
-  const firstSectionIdRef = useRef<string | null>(null);
-
-  // R3: shared updateSong via factory
   const updateSong = makeSongUpdater(updateState);
 
   const uiLang = uiLanguage === 'fr' ? 'French'
@@ -124,7 +82,7 @@ export const useLanguageAdapter = ({
     : uiLanguage === 'ko' ? 'Korean'
     : 'English';
 
-  // Detect song identity change (covers load-from-library via replaceStateWithoutHistory).
+  // Detect song identity change.
   useEffect(() => {
     if (song.length === 0) return;
     const currentFirstId = song[0]!.id;
@@ -137,20 +95,14 @@ export const useLanguageAdapter = ({
 
   // Auto-detect language once when song first becomes non-empty.
   useEffect(() => {
-    if (
-      song.length > 0 &&
-      !songLanguage &&
-      !isGenerating &&
-      !isAdaptingLanguage &&
-      !autoDetectFiredRef.current
-    ) {
+    if (song.length > 0 && !songLanguage && !isGenerating && !isAdaptingLanguage && !autoDetectFiredRef.current) {
       autoDetectFiredRef.current = true;
       void detectLanguage();
     }
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [song.length, songLanguage, isGenerating, isAdaptingLanguage]);
 
-  // Reset the auto-detect gate when the song is cleared.
+  // Reset when song is cleared.
   useEffect(() => {
     if (song.length === 0) {
       autoDetectFiredRef.current = false;
@@ -159,99 +111,8 @@ export const useLanguageAdapter = ({
     }
   }, [song.length, setSongLanguage]);
 
-  // -------------------------------------------------------------------------
-  // Helpers
-  // -------------------------------------------------------------------------
-
-  const setStep = (id: AdaptationStepId, label: string) => {
+  const setStep = (id: AdaptationStepId, label: string) =>
     setAdaptationProgress(prev => ({ ...prev, active: id, label }));
-  };
-
-  // -------------------------------------------------------------------------
-  // Reverse-translate
-  // -------------------------------------------------------------------------
-  const reverseTranslate = async (
-    adaptedSong: Section[],
-    fromLanguage: string,
-    toLanguage: string,
-  ): Promise<string[]> => {
-    const lines = adaptedSong.flatMap(s =>
-      s.lines.filter(l => !l.isMeta).map(l => l.text)
-    );
-    if (lines.length === 0) return [];
-
-    const response = await getAi().models.generateContent({
-      model: AI_MODEL_NAME,
-      contents: [
-        `You are a professional literal translator. Translate the following ${fromLanguage} lyrics LITERALLY (word-for-word, no adaptation) into ${toLanguage}.`,
-        `Return a JSON array of strings, one translated string per input line, preserving order exactly.`,
-        `Input lines (${fromLanguage}):`,
-        JSON.stringify(lines),
-      ].join('\n'),
-      config: {
-        responseMimeType: 'application/json',
-        responseSchema: {
-          type: Type.ARRAY,
-          items: { type: Type.STRING },
-        },
-      },
-    });
-    return safeJsonParse<string[]>(response.text || '[]', []);
-  };
-
-  // -------------------------------------------------------------------------
-  // Review fidelity
-  // -------------------------------------------------------------------------
-  const reviewFidelity = async (
-    originalSong: Section[],
-    reversedLines: string[],
-    targetLanguage: string,
-    sourceLang: string,
-  ): Promise<{ score: number; warnings: string[] }> => {
-    const originalLines = originalSong
-      .flatMap(s => s.lines.filter(l => !l.isMeta).map(l => l.text));
-
-    const reviewPrompt = [
-      `You are a senior lyric consultant reviewing the conceptual fidelity of a song adaptation from ${sourceLang} to ${targetLanguage}.`,
-      ``,
-      `You have:`,
-      `- ORIGINAL lyrics in ${sourceLang}`,
-      `- REVERSE TRANSLATION of the ${targetLanguage} adaptation (literal, back into ${sourceLang})`,
-      ``,
-      `Your task: assess whether the ${targetLanguage} adaptation preserved the conceptual intent of the original.`,
-      ``,
-      `Return a JSON object with:`,
-      `- "score": integer 0-100 (100 = perfect fidelity, 0 = completely lost the meaning)`,
-      `- "warnings": array of strings describing specific intent losses (empty array if none)`,
-      ``,
-      `ORIGINAL (${sourceLang}):`,
-      JSON.stringify(originalLines),
-      ``,
-      `REVERSE TRANSLATION (back to ${sourceLang}):`,
-      JSON.stringify(reversedLines),
-    ].join('\n');
-
-    const response = await getAi().models.generateContent({
-      model: AI_MODEL_NAME,
-      contents: reviewPrompt,
-      config: {
-        responseMimeType: 'application/json',
-        responseSchema: {
-          type: Type.OBJECT,
-          properties: {
-            score:    { type: Type.INTEGER },
-            warnings: { type: Type.ARRAY, items: { type: Type.STRING } },
-          },
-          required: ['score', 'warnings'],
-        },
-      },
-    });
-
-    return safeJsonParse<{ score: number; warnings: string[] }>(
-      response.text || '{"score":50,"warnings":[]}',
-      { score: 50, warnings: [] },
-    );
-  };
 
   // -------------------------------------------------------------------------
   // Public: detect language
@@ -265,8 +126,7 @@ export const useLanguageAdapter = ({
         model: AI_MODEL_NAME,
         contents: `Detect the language of these lyrics. Return ONLY the name of the language in English (e.g., "English", "French", "Spanish").\n\nLyrics:\n${songText.substring(0, 1000)}`,
       });
-      const detected = response.text?.trim() || 'English';
-      setSongLanguage(detected);
+      setSongLanguage(response.text?.trim() || 'English');
     } catch (error) {
       console.error('Language detection error:', error);
     } finally {
@@ -281,7 +141,7 @@ export const useLanguageAdapter = ({
     if (song.length === 0 || newLanguage === songLanguage) return;
 
     const sourceLanguage = songLanguage || 'unknown';
-    const progressLabel  = `${sourceLanguage} → ${newLanguage}`;
+    const progressLabel  = `${sourceLanguage} \u2192 ${newLanguage}`;
 
     setIsAdaptingLanguage(true);
     setAdaptationResult(null);
@@ -291,45 +151,7 @@ export const useLanguageAdapter = ({
     try {
       setStep('adapting', progressLabel);
 
-      const adaptPrompt = `You are an expert lyricist specializing in creative song adaptation across languages.
-
-Your task: Adapt the following song lyrics to ${newLanguage} with CREATIVE ADAPTATION, not literal translation.
-
-CRITICAL GUIDELINES:
-
-1. EMOTIONAL IMPACT FIRST
-   - Preserve the emotional journey and core message
-   - Prioritize how the lyrics make people FEEL over word-for-word accuracy
-   - Maintain the song's vibe, tone, and artistic intent
-
-2. NATURAL LANGUAGE
-   - Write as if the song was originally composed in ${newLanguage}
-   - Use idioms, expressions, and cultural references native to ${newLanguage}
-   - Avoid "translation-speak" - make it sound authentic and poetic
-   - Respect ${newLanguage} grammar, syntax, and natural word order
-
-3. POETIC STRUCTURE
-   - Maintain rhyme scheme quality (e.g., if AABB, keep clean rhymes in ${newLanguage})
-   - Match syllable counts when possible, but prioritize natural phrasing
-   - Preserve rhythm and singability
-   - Adapt imagery and metaphors to resonate in the target culture
-
-4. CULTURAL ADAPTATION
-   - Replace culture-specific references with equivalent concepts in ${newLanguage} culture
-   - Adapt humor, wordplay, and double meanings creatively
-   - Ensure themes and stories make sense to ${newLanguage} speakers
-
-5. TECHNICAL REQUIREMENTS
-   - Maintain the existing section structure (same section names)
-   - Return the FULL updated song in the same JSON format as input
-   - Update rhymingSyllables to reflect actual ${newLanguage} rhymes
-   - Adjust syllable counts to match the adapted lyrics
-   - Write the "concept" field for each line in ${uiLang}
-
-Current Song Data:
-${JSON.stringify(song)}
-
-Return the fully adapted song that feels native to ${newLanguage} speakers while preserving the soul of the original.`;
+      const adaptPrompt = `You are an expert lyricist specializing in creative song adaptation across languages.\n\nYour task: Adapt the following song lyrics to ${newLanguage} with CREATIVE ADAPTATION, not literal translation.\n\nCRITICAL GUIDELINES:\n\n1. EMOTIONAL IMPACT FIRST\n   - Preserve the emotional journey and core message\n   - Prioritize how the lyrics make people FEEL over word-for-word accuracy\n   - Maintain the song's vibe, tone, and artistic intent\n\n2. NATURAL LANGUAGE\n   - Write as if the song was originally composed in ${newLanguage}\n   - Use idioms, expressions, and cultural references native to ${newLanguage}\n   - Avoid "translation-speak" - make it sound authentic and poetic\n   - Respect ${newLanguage} grammar, syntax, and natural word order\n\n3. POETIC STRUCTURE\n   - Maintain rhyme scheme quality (e.g., if AABB, keep clean rhymes in ${newLanguage})\n   - Match syllable counts when possible, but prioritize natural phrasing\n   - Preserve rhythm and singability\n   - Adapt imagery and metaphors to resonate in the target culture\n\n4. CULTURAL ADAPTATION\n   - Replace culture-specific references with equivalent concepts in ${newLanguage} culture\n   - Adapt humor, wordplay, and double meanings creatively\n   - Ensure themes and stories make sense to ${newLanguage} speakers\n\n5. TECHNICAL REQUIREMENTS\n   - Maintain the existing section structure (same section names)\n   - Return the FULL updated song in the same JSON format as input\n   - Update rhymingSyllables to reflect actual ${newLanguage} rhymes\n   - Adjust syllable counts to match the adapted lyrics\n   - Write the "concept" field for each line in ${uiLang}\n\nCurrent Song Data:\n${JSON.stringify(song)}\n\nReturn the fully adapted song that feels native to ${newLanguage} speakers while preserving the soul of the original.`;
 
       const adaptResponse = await getAi().models.generateContent({
         model: AI_MODEL_NAME,
@@ -397,7 +219,7 @@ Return the fully adapted song that feels native to ${newLanguage} speakers while
     if (!section) return;
 
     const sourceLanguage = songLanguage || 'unknown';
-    const progressLabel  = `${section.name}: ${sourceLanguage} → ${newLanguage}`;
+    const progressLabel  = `${section.name}: ${sourceLanguage} \u2192 ${newLanguage}`;
 
     setIsAdaptingLanguage(true);
     setAdaptationResult(null);
@@ -407,14 +229,7 @@ Return the fully adapted song that feels native to ${newLanguage} speakers while
     try {
       setStep('adapting', progressLabel);
 
-      const sectionPrompt = `You are an expert lyricist specializing in creative song adaptation across languages.
-
-Adapt the following song section to ${newLanguage} with CREATIVE ADAPTATION, not literal translation.
-Keep section name unchanged. Update rhymingSyllables. Adjust syllable counts.
-Write the "concept" field for each line in ${uiLang}.
-
-Current Section Data:
-${JSON.stringify(section)}`;
+      const sectionPrompt = `You are an expert lyricist specializing in creative song adaptation across languages.\n\nAdapt the following song section to ${newLanguage} with CREATIVE ADAPTATION, not literal translation.\nKeep section name unchanged. Update rhymingSyllables. Adjust syllable counts.\nWrite the "concept" field for each line in ${uiLang}.\n\nCurrent Section Data:\n${JSON.stringify(section)}`;
 
       const adaptResponse = await getAi().models.generateContent({
         model: AI_MODEL_NAME,
@@ -449,11 +264,7 @@ ${JSON.stringify(section)}`;
       const newSectionData = safeJsonParse<any>(adaptResponse.text || '{}', {});
       if (!newSectionData.name) throw new Error('Empty section adaptation response');
 
-      const adaptedSectionSong: Section[] = [{
-        ...section,
-        lines: newSectionData.lines ?? section.lines,
-        language: newLanguage,
-      }];
+      const adaptedSectionSong: Section[] = [{ ...section, lines: newSectionData.lines ?? section.lines, language: newLanguage }];
 
       updateSong(currentSong =>
         currentSong.map(currentSection => {
@@ -466,8 +277,7 @@ ${JSON.stringify(section)}`;
       const reversedLines = await reverseTranslate(adaptedSectionSong, newLanguage, sourceLanguage);
 
       setStep('reviewing', progressLabel);
-      const originalSectionSong: Section[] = [section];
-      const { score, warnings } = await reviewFidelity(originalSectionSong, reversedLines, newLanguage, sourceLanguage);
+      const { score, warnings } = await reviewFidelity([section], reversedLines, newLanguage, sourceLanguage);
 
       const result: AdaptationResult = { score, warnings, accepted: score >= 50, targetLanguage: newLanguage };
       setAdaptationResult(result);
@@ -482,18 +292,11 @@ ${JSON.stringify(section)}`;
   };
 
   return {
-    songLanguage,
-    setSongLanguage,
-    targetLanguage,
-    setTargetLanguage,
-    sectionTargetLanguages,
-    setSectionTargetLanguages,
-    isDetectingLanguage,
-    isAdaptingLanguage,
-    adaptationProgress,
-    adaptationResult,
-    detectLanguage,
-    adaptSongLanguage,
-    adaptSectionLanguage,
+    songLanguage, setSongLanguage,
+    targetLanguage, setTargetLanguage,
+    sectionTargetLanguages, setSectionTargetLanguages,
+    isDetectingLanguage, isAdaptingLanguage,
+    adaptationProgress, adaptationResult,
+    detectLanguage, adaptSongLanguage, adaptSectionLanguage,
   };
 };


### PR DESCRIPTION
## Objectif
Décompose `useLanguageAdapter.ts` (18 KB, 3 responsabilités) en 3 modules dans `src/hooks/analysis/`.

## Fichiers créés / modifiés
| Fichier | Responsabilité |
|---|---|
| `languageAdapterTypes.ts` | Types + constantes (`PIPELINE_STEPS`, `IDLE_PROGRESS`) |
| `languageAdapterPipeline.ts` | `reverseTranslate` + `reviewFidelity` — helpers stateless purs |
| `useLanguageAdapter.ts` | Hook orchestrateur ~170 lignes, public API identique |

## Compatibilité
- Re-export des types depuis `useLanguageAdapter.ts` → aucun import consommateur à changer.
- `songLanguage` / `setSongLanguage` toujours passés en params depuis `useAppState` → pas d’impact Chantier 1.
- Pipeline isolé en fonctions pures : testable unité par unité sans mock de hook.

## Notes
- Branche indépendante de 3.3.2 : peut merger dans n’importe quel ordre.