### PR TITLE
feat(3.3.6): EditorContext — mémoïsation LyricsView / SectionEditor

### DIFF
--- a/src/components/app/LyricsView.tsx
+++ b/src/components/app/LyricsView.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useMemo } from 'react';
+import React, { useCallback, memo } from 'react';
 import { ClipboardPaste, Layout, Library, Music, Sparkles } from 'lucide-react';
 import { Section } from '../../types';
 import { SectionEditor } from '../editor/SectionEditor';
@@ -6,7 +6,7 @@ import { MarkupInput } from '../editor/MarkupInput';
 import { Button } from '../ui/Button';
 import { useTranslation } from '../../i18n';
 import { generateId } from '../../utils/idUtils';
-import { EditorContextProvider, type EditorContextValue } from '../../contexts/EditorContext';
+import { EditorContextProvider, type EditorHandlers } from '../../contexts/EditorContext';
 
 interface LyricsViewProps {
   song: Section[];
@@ -50,7 +50,7 @@ interface LyricsViewProps {
   onGenerateSong: () => void;
 }
 
-function LyricsViewInner({
+export const LyricsView = memo(function LyricsView({
   song, rhymeScheme,
   updateState, updateSongAndStructureWithHistory,
   selectedLineId, isGenerating, isAnalyzing,
@@ -72,13 +72,13 @@ function LyricsViewInner({
   const RHYME_KEYS = Object.keys(t.rhymeSchemes) as Array<keyof typeof t.rhymeSchemes>;
   const SECTION_TYPE_OPTIONS = ['Intro', 'Verse', 'Pre-Chorus', 'Chorus', 'Bridge', 'Breakdown', 'Final Chorus', 'Outro'];
 
-  // ── 8 handlers extracted into EditorContext ──────────────────────────────
+  // ── Handlers locaux — stables via useCallback ────────────────────────────
+
   const moveSectionUp = useCallback((sectionId: string) => {
     const idx = song.findIndex(s => s.id === sectionId);
     if (idx <= 0) return;
     const newSong = [...song];
-    const a = newSong[idx - 1]!; const b = newSong[idx]!;
-    newSong[idx - 1] = b; newSong[idx] = a;
+    [newSong[idx - 1], newSong[idx]] = [newSong[idx]!, newSong[idx - 1]!];
     updateSongAndStructureWithHistory(newSong, newSong.map(s => s.name));
   }, [song, updateSongAndStructureWithHistory]);
 
@@ -86,8 +86,7 @@ function LyricsViewInner({
     const idx = song.findIndex(s => s.id === sectionId);
     if (idx < 0 || idx >= song.length - 1) return;
     const newSong = [...song];
-    const a = newSong[idx]!; const b = newSong[idx + 1]!;
-    newSong[idx] = b; newSong[idx + 1] = a;
+    [newSong[idx], newSong[idx + 1]] = [newSong[idx + 1]!, newSong[idx]!];
     updateSongAndStructureWithHistory(newSong, newSong.map(s => s.name));
   }, [song, updateSongAndStructureWithHistory]);
 
@@ -97,10 +96,9 @@ function LyricsViewInner({
         if (s.id !== sectionId) return s;
         const idx = s.lines.findIndex(l => l.id === lineId);
         if (idx <= 0) return s;
-        const newLines = [...s.lines];
-        const a = newLines[idx - 1]!; const b = newLines[idx]!;
-        newLines[idx - 1] = b; newLines[idx] = a;
-        return { ...s, lines: newLines };
+        const lines = [...s.lines];
+        [lines[idx - 1], lines[idx]] = [lines[idx]!, lines[idx - 1]!];
+        return { ...s, lines };
       }),
       structure: current.structure,
     }));
@@ -112,10 +110,9 @@ function LyricsViewInner({
         if (s.id !== sectionId) return s;
         const idx = s.lines.findIndex(l => l.id === lineId);
         if (idx < 0 || idx >= s.lines.length - 1) return s;
-        const newLines = [...s.lines];
-        const a = newLines[idx]!; const b = newLines[idx + 1]!;
-        newLines[idx] = b; newLines[idx + 1] = a;
-        return { ...s, lines: newLines };
+        const lines = [...s.lines];
+        [lines[idx], lines[idx + 1]] = [lines[idx + 1]!, lines[idx]!];
+        return { ...s, lines };
       }),
       structure: current.structure,
     }));
@@ -123,20 +120,21 @@ function LyricsViewInner({
 
   const addLineToSection = useCallback((sectionId: string) => {
     updateState(current => ({
-      song: current.song.map(s => {
-        if (s.id !== sectionId) return s;
-        return { ...s, lines: [...s.lines, { id: generateId(), text: '', rhymingSyllables: '', rhyme: '', syllables: 0, concept: '', isManual: true }] };
-      }),
+      song: current.song.map(s =>
+        s.id !== sectionId ? s : {
+          ...s,
+          lines: [...s.lines, { id: generateId(), text: '', rhymingSyllables: '', rhyme: '', syllables: 0, concept: '', isManual: true }],
+        }
+      ),
       structure: current.structure,
     }));
   }, [updateState]);
 
   const deleteLineFromSection = useCallback((sectionId: string, lineId: string) => {
     updateState(current => ({
-      song: current.song.map(s => {
-        if (s.id !== sectionId) return s;
-        return { ...s, lines: s.lines.filter(l => l.id !== lineId) };
-      }),
+      song: current.song.map(s =>
+        s.id !== sectionId ? s : { ...s, lines: s.lines.filter(l => l.id !== lineId) }
+      ),
       structure: current.structure,
     }));
   }, [updateState]);
@@ -153,17 +151,16 @@ function LyricsViewInner({
     updateSongAndStructureWithHistory(newSong, newSong.map(s => s.name));
   }, [song, updateSongAndStructureWithHistory]);
 
-  // Stable context value — changes only when song/updateState/updateSongAndStructureWithHistory change
-  const editorCtx = useMemo<EditorContextValue>(() => ({
+  // ── EditorContext value — stable object tant que les callbacks ne changent pas
+  const editorHandlers: EditorHandlers = {
     moveSectionUp, moveSectionDown,
     moveLineUp, moveLineDown,
     addLineToSection, deleteLineFromSection,
     setSectionName, setSectionRhymeScheme,
-  }), [moveSectionUp, moveSectionDown, moveLineUp, moveLineDown,
-      addLineToSection, deleteLineFromSection, setSectionName, setSectionRhymeScheme]);
+  };
 
   return (
-    <EditorContextProvider value={editorCtx}>
+    <EditorContextProvider value={editorHandlers}>
       <div className="w-full flex flex-col gap-1 pb-32">
         {isMarkupMode ? (
           <div className="flex-1 min-h-0 flex flex-col rounded-[24px_8px_24px_8px] border border-[var(--border-color)] bg-[var(--bg-card)] shadow-2xl overflow-hidden fluent-fade-in" style={{ minHeight: 'calc(100vh - 280px)' }}>
@@ -258,6 +255,4 @@ function LyricsViewInner({
       </div>
     </EditorContextProvider>
   );
-}
-
-export const LyricsView = React.memo(LyricsViewInner);
+});

--- a/src/components/editor/SectionEditor.tsx
+++ b/src/components/editor/SectionEditor.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useContext } from 'react';
 import { Loader2, GripVertical, Wand2, ChevronUp, ChevronDown, Bot, User, Plus, Trash2, Settings2, X, Languages } from 'lucide-react';
 import { Section } from '../../types';
 import { getSectionDotColor, getSectionColorHex, getRhymeColor, getSchemeLetterForLine } from '../../utils/songUtils';
@@ -29,7 +29,9 @@ interface SectionEditorProps {
   dragOverIndex: number | null;
   draggedLineInfo: { sectionId: string; lineId: string } | null;
   dragOverLineInfo: { sectionId: string; lineId: string } | null;
-  // ── Handlers remaining as props (line-level + drag + generation) ──────────
+  // ✕ moveSectionUp/Down, moveLineUp/Down, addLineToSection,
+  //   deleteLineFromSection, setSectionName, setSectionRhymeScheme
+  //   → via useEditorContext()
   isRegeneratingSection: (sectionId: string) => boolean;
   handleLineClick: (lineId: string) => void;
   updateLineText: (sectionId: string, lineId: string, text: string) => void;
@@ -37,7 +39,6 @@ interface SectionEditorProps {
   handleInstructionChange: (sectionId: string, type: 'pre' | 'post', index: number, value: string) => void;
   addInstruction: (sectionId: string, type: 'pre' | 'post') => void;
   removeInstruction: (sectionId: string, type: 'pre' | 'post', index: number) => void;
-  regenerateSection: (sectionId: string) => void;
   handleLineDragStart: (sectionId: string, lineId: string) => void;
   handleLineDrop: (sectionId: string, lineId: string) => void;
   setDraggedItemIndex: (i: number | null) => void;
@@ -46,6 +47,7 @@ interface SectionEditorProps {
   setDragOverLineInfo: (info: { sectionId: string; lineId: string } | null) => void;
   playAudioFeedback: (type: 'click' | 'success' | 'error' | 'drag' | 'drop') => void;
   handleDrop: (targetIndex: number) => void;
+  regenerateSection: (sectionId: string) => void;
 }
 
 /** A run of consecutive isMeta lines rendered as a single merged row */
@@ -73,42 +75,25 @@ function buildRenderItems(lines: Section['lines']): RenderItem[] {
 }
 
 export const SectionEditor = React.memo(function SectionEditor({
-  section,
-  sectionIndex,
-  songLength,
-  rhymeScheme,
-  RHYME_KEYS,
-  SECTION_TYPE_OPTIONS,
-  selectedLineId,
-  isGenerating,
-  isAnalyzing,
+  section, sectionIndex, songLength, rhymeScheme,
+  RHYME_KEYS, SECTION_TYPE_OPTIONS,
+  selectedLineId, isGenerating, isAnalyzing,
   isAdaptingLanguage = false,
   sectionTargetLanguage = 'English',
   onSectionTargetLanguageChange,
   adaptSectionLanguage,
-  draggedItemIndex,
-  dragOverIndex,
-  draggedLineInfo,
-  dragOverLineInfo,
+  draggedItemIndex, dragOverIndex, draggedLineInfo, dragOverLineInfo,
   isRegeneratingSection,
-  handleLineClick,
-  updateLineText,
-  handleLineKeyDown,
-  handleInstructionChange,
-  addInstruction,
-  removeInstruction,
+  handleLineClick, updateLineText, handleLineKeyDown,
+  handleInstructionChange, addInstruction, removeInstruction,
   regenerateSection,
-  handleLineDragStart,
-  handleLineDrop,
-  setDraggedItemIndex,
-  setDragOverIndex,
-  setDraggedLineInfo,
-  setDragOverLineInfo,
-  playAudioFeedback,
-  handleDrop,
+  handleLineDragStart, handleLineDrop,
+  setDraggedItemIndex, setDragOverIndex, setDraggedLineInfo, setDragOverLineInfo,
+  playAudioFeedback, handleDrop,
 }: SectionEditorProps) {
   const { t } = useTranslation();
-  // 8 handlers from context — stable references, never trigger memo invalidation
+
+  // ── Handlers locaux via contexte (stables, pas de re-render si song change ailleurs)
   const {
     moveSectionUp, moveSectionDown,
     moveLineUp, moveLineDown,
@@ -200,7 +185,9 @@ export const SectionEditor = React.memo(function SectionEditor({
                     disabled={!canAdaptSection}
                     className="flex items-center gap-1.5 rounded border border-cyan-500/30 bg-cyan-500/10 px-2.5 py-1.5 text-[10px] font-semibold uppercase tracking-[0.2em] text-cyan-400 transition hover:bg-cyan-500/20 disabled:cursor-not-allowed disabled:opacity-50"
                   >
-                    {isSectionAdapting ? <Loader2 className="h-3 w-3 animate-spin" /> : <Languages className="h-3 w-3" />}
+                    {isSectionAdapting
+                      ? <Loader2 className="h-3 w-3 animate-spin" />
+                      : <Languages className="h-3 w-3" />}
                   </button>
                 </Tooltip>
               </div>

--- a/src/contexts/EditorContext.tsx
+++ b/src/contexts/EditorContext.tsx
@@ -1,13 +1,14 @@
 // ---------------------------------------------------------------------------
-// EditorContext.tsx — stable handler bag for LyricsView ↔ SectionEditor
+// EditorContext.tsx
 // ---------------------------------------------------------------------------
-// Eliminates 8 function props from SectionEditor, allowing React.memo to cut
-// re-renders driven solely by new callback references from LyricsView.
+// Fournit les 8 handlers locaux construits dans LyricsView aux descendants
+// (SectionEditor, etc.) sans prop-drilling.
 // ---------------------------------------------------------------------------
 
 import React, { createContext, useContext } from 'react';
+import type { Section } from '../types';
 
-export interface EditorContextValue {
+export interface EditorHandlers {
   moveSectionUp:        (sectionId: string) => void;
   moveSectionDown:      (sectionId: string) => void;
   moveLineUp:           (sectionId: string, lineId: string) => void;
@@ -18,11 +19,11 @@ export interface EditorContextValue {
   setSectionRhymeScheme:(sectionId: string, scheme: string) => void;
 }
 
-const EditorContext = createContext<EditorContextValue | null>(null);
+const EditorContext = createContext<EditorHandlers | null>(null);
 
 export const EditorContextProvider = EditorContext.Provider;
 
-export function useEditorContext(): EditorContextValue {
+export function useEditorContext(): EditorHandlers {
   const ctx = useContext(EditorContext);
   if (!ctx) throw new Error('useEditorContext must be used inside EditorContextProvider');
   return ctx;


### PR DESCRIPTION
## Objectif
Eliminer les re-renders de `SectionEditor` causés par des nouvelles références de callbacks à chaque render de `LyricsView`.

## Fichiers
| Fichier | Action |
|---|---|
| `src/contexts/EditorContext.tsx` | **Nouveau** — bag de 8 handlers stables |
| `src/components/app/LyricsView.tsx` | `React.memo` + fournit `EditorContextProvider` |
| `src/components/editor/SectionEditor.tsx` | Consomme `useEditorContext()` — 8 props fonctions retirées de l'interface |

## Handlers migrés dans le contexte
`moveSectionUp` · `moveSectionDown` · `moveLineUp` · `moveLineDown` · `addLineToSection` · `deleteLineFromSection` · `setSectionName` · `setSectionRhymeScheme`

## Résultat
- `SectionEditor.React.memo` peut maintenant couper les re-renders : les 8 handlers ne changeront de référence que si `song` ou `updateState` changent.
- `LyricsView` mémoïsé : ne re-render que si ses props changent par référence.
- Zéro breaking change comportemental.