### PR TITLE
fix(audit-pr1): dedup paste handler, document orphan exports · v3.17.45

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -261,7 +261,9 @@ function AppInnerContent() {
       setSectionTargetLanguages(prev => ({ ...prev, [sectionId]: lang })),
     [setSectionTargetLanguages]
   );
-  const handlePasteLyricsFromView = useCallback(() => setIsPasteModalOpen(true), [setIsPasteModalOpen]);
+  // Paste handler — point d'entrée unique pour ouvrir la modale de collage
+  // (utilisé depuis LyricsView, TopRibbon et AppModals via handleOpenPasteLyricsFromModals)
+  const handleOpenPasteModal = useCallback(() => setIsPasteModalOpen(true), [setIsPasteModalOpen]);
   const handleOpenPasteLyricsFromModals = useCallback(() => {
     setIsImportModalOpen(false);
     setIsPasteModalOpen(true);
@@ -274,7 +276,6 @@ function AppInnerContent() {
     () => setIsKeyboardShortcutsModalOpen(true),
     [setIsKeyboardShortcutsModalOpen]
   );
-  const handlePasteLyricsFromRibbon = useCallback(() => setIsPasteModalOpen(true), [setIsPasteModalOpen]);
 
   return (
     <ModalProvider uiState={uiStateForProvider}>
@@ -325,7 +326,7 @@ function AppInnerContent() {
               onOpenSettingsClick={handleOpenSettings}
               onOpenAboutClick={handleOpenAbout}
               onOpenKeyboardShortcutsClick={handleOpenKeyboardShortcuts}
-              onPasteLyrics={handlePasteLyricsFromRibbon}
+              onPasteLyrics={handleOpenPasteModal}
               isAnalyzing={isAnalyzing}
             />
             {activeTab === 'lyrics' && song.length > 0 && (
@@ -358,7 +359,7 @@ function AppInnerContent() {
                        markupText={markupText} setMarkupText={setMarkupText} markupTextareaRef={markupTextareaRef}
                        markupDirection={markupDirection}
                        onOpenLibrary={handleOpenSaveToLibraryModal}
-                       onPasteLyrics={handlePasteLyricsFromView}
+                       onPasteLyrics={handleOpenPasteModal}
                        onGenerateSong={handleGlobalRegenerate}
                      />
                   ) : (

--- a/src/hooks/useSongAnalysis.ts
+++ b/src/hooks/useSongAnalysis.ts
@@ -88,15 +88,22 @@ export const useSongAnalysis = ({
   });
 
   return {
+    // ── Paste import ────────────────────────────────────────────────────────
     pastedText: pasteImport.pastedText,
     setPastedText: pasteImport.setPastedText,
+    analyzePastedLyrics: pasteImport.analyzePastedLyrics,
+    // ── Analysis state ──────────────────────────────────────────────────────
     isAnalyzing,
     analysisReport: analysisEngine.analysisReport,
     analysisSteps: analysisEngine.analysisSteps,
     appliedAnalysisItems: analysisEngine.appliedAnalysisItems,
     selectedAnalysisItems: analysisEngine.selectedAnalysisItems,
     isApplyingAnalysis: analysisEngine.isApplyingAnalysis,
-    isAnalyzingTheme: analysisEngine.isAnalyzingTheme,
+    toggleAnalysisItemSelection: analysisEngine.toggleAnalysisItemSelection,
+    applySelectedAnalysisItems: analysisEngine.applySelectedAnalysisItems,
+    analyzeCurrentSong: analysisEngine.analyzeCurrentSong,
+    clearAppliedAnalysisItems: analysisEngine.clearAppliedAnalysisItems,
+    // ── Language adapter ────────────────────────────────────────────────────
     songLanguage: languageAdapter.songLanguage,
     targetLanguage: languageAdapter.targetLanguage,
     setTargetLanguage: languageAdapter.setTargetLanguage,
@@ -106,14 +113,13 @@ export const useSongAnalysis = ({
     isAdaptingLanguage: languageAdapter.isAdaptingLanguage,
     adaptationProgress: languageAdapter.adaptationProgress,
     adaptationResult: languageAdapter.adaptationResult,
-    toggleAnalysisItemSelection: analysisEngine.toggleAnalysisItemSelection,
-    applySelectedAnalysisItems: analysisEngine.applySelectedAnalysisItems,
-    applyAnalysisItem: analysisEngine.applyAnalysisItem,
-    analyzeCurrentSong: analysisEngine.analyzeCurrentSong,
     detectLanguage: languageAdapter.detectLanguage,
     adaptSongLanguage: languageAdapter.adaptSongLanguage,
     adaptSectionLanguage: languageAdapter.adaptSectionLanguage,
-    analyzePastedLyrics: pasteImport.analyzePastedLyrics,
-    clearAppliedAnalysisItems: analysisEngine.clearAppliedAnalysisItems,
+    // ── @internal: non consommés par App.tsx — conserver pour les tests ────
+    // TODO: brancher isAnalyzingTheme sur InsightsBar ou supprimer
+    // TODO: brancher applyAnalysisItem sur un futur point d'usage ou supprimer
+    isAnalyzingTheme: analysisEngine.isAnalyzingTheme,
+    applyAnalysisItem: analysisEngine.applyAnalysisItem,
   };
 };

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,2 +1,2 @@
-export const APP_VERSION = 'v3.17.44';
+export const APP_VERSION = 'v3.17.45';
 export const APP_VERSION_LABEL = `β ${APP_VERSION}`;


### PR DESCRIPTION
## Contexte
Suite à l'audit complet de LYRICIST (24 mars 2026). Cette PR est la première d'un plan en 3 étapes.

## Changements

### `src/App.tsx`
- **Déduplication du paste handler** : `handlePasteLyricsFromView` et `handlePasteLyricsFromRibbon` étaient deux handlers identiques (`() => setIsPasteModalOpen(true)`). Remplacés par un seul `handleOpenPasteModal`, utilisé depuis `LyricsView`, `TopRibbon` et `AppModals`.
- Point d'entrée distinct conservé pour `handleOpenPasteLyricsFromModals` (ferme la modale d'import avant d'ouvrir la modale de collage — séquence intentionnellement différente).

### `src/hooks/useSongAnalysis.ts`
- `isAnalyzingTheme` et `applyAnalysisItem` déplacés en fin de return et annotés `@internal` avec TODO : ces exports ne sont pas consommés par `App.tsx` (confirmé par recherche cross-repo). Exports conservés pour ne pas casser les tests existants (`useSongAnalysisEngine.test.ts`).
- Sections du return organisées par blocs commentés (paste / analysis / language adapter) pour meilleure lisibilité.

### `src/version.ts`
- `v3.17.44` → `v3.17.45`

## PRs suivantes
- **PR-2** : `React.memo` sur `AppModals`, `InsightsBar`, `StructureSidebar` + nettoyage `useMemo` dans `useUIStateForProvider`
- **PR-3** : Refactoring props `AppModals` en sous-objets thématiques

## Risque de régression
Minimal — aucune logique métier modifiée, seule la surface d'API interne est consolidée.