### PR TITLE
perf(memo): React.memo on AppModals, InsightsBar, StructureSidebar · v3.17.46

### DIFF
--- a/src/components/app/AppModals.tsx
+++ b/src/components/app/AppModals.tsx
@@ -103,7 +103,7 @@ interface Props {
   resetSong: () => void;
 }
 
-export function AppModals({
+export const AppModals = React.memo(function AppModals({
   theme, setTheme, audioFeedback, setAudioFeedback, uiScale, setUiScale, defaultEditMode, setDefaultEditMode,
   hasExistingWork, handleImportChooseFile, onOpenPasteLyrics, handleImportInputChange,
   exportSong,
@@ -206,4 +206,4 @@ export function AppModals({
       />
     </>
   );
-}
+});

--- a/src/components/app/InsightsBar.tsx
+++ b/src/components/app/InsightsBar.tsx
@@ -203,7 +203,7 @@ function AdaptationProgressBanner({
 // InsightsBar
 // ---------------------------------------------------------------------------
 
-export function InsightsBar({
+export const InsightsBar = React.memo(function InsightsBar({
   targetLanguage,
   setTargetLanguage,
   isAdaptingLanguage,
@@ -418,4 +418,4 @@ export function InsightsBar({
       </div>
     </div>
   );
-}
+});

--- a/src/components/app/StructureSidebar.tsx
+++ b/src/components/app/StructureSidebar.tsx
@@ -35,7 +35,7 @@ interface Props {
   className?: string;
 }
 
-export function StructureSidebar({
+export const StructureSidebar = React.memo(function StructureSidebar({
   isStructureOpen, setIsStructureOpen,
   newSectionName, setNewSectionName,
   isSectionDropdownOpen, setIsSectionDropdownOpen,
@@ -180,7 +180,6 @@ export function StructureSidebar({
                       );
 
                       if (isGroupLeader && chorusItem !== undefined && chorusIdx !== undefined) {
-                        // Render Pre-Chorus + Chorus as a coupled group
                         return (
                           <div
                             key={idx}
@@ -319,4 +318,4 @@ export function StructureSidebar({
       )}
     </AnimatePresence>
   );
-}
+});

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,2 +1,2 @@
-export const APP_VERSION = 'v3.17.45';
+export const APP_VERSION = 'v3.17.46';
 export const APP_VERSION_LABEL = `β ${APP_VERSION}`;


### PR DESCRIPTION
## Contexte
Suite à l'audit LYRICIST (24 mars 2026) — PR-2 du plan en 3 étapes.

## Changements

### `src/components/app/AppModals.tsx`
- `export function AppModals` → `export const AppModals = React.memo(function AppModals(...))`
- Aucune modification de logique. Toutes les props fonctions sont déjà `useCallback` dans `App.tsx` → memo efficace immédiatement.

### `src/components/app/InsightsBar.tsx`
- Même pattern. `InsightsBar` reçoit des handlers stables (`handleGlobalRegenerate`, `analyzeCurrentSong`, `handleMarkupToggle`, etc.) — tous `useCallback` en amont.

### `src/components/app/StructureSidebar.tsx`
- Même pattern. Props fonctions (`addStructureItem`, `removeStructureItem`, `normalizeStructure`, `handleDrop`, `onScrollToSection`) issues de hooks ou `useCallback`.

### `src/version.ts`
- `v3.17.45` → `v3.17.46`

## Non-inclus (décision délibérée)
- `useUIStateForProvider` : déjà correctement segmenté en 4 blocs `useMemo`. Les setters React dans les deps sont inoffensifs (stables par définition). Cleanup cosmétique dépriorisé.

## Risque de régression
Nul — `React.memo` est un wrapper transparent, aucune logique modifiée.