### PR TITLE
fix(security): whitelist SDK config keys in api/generate — v3.21.6

### DIFF
--- a/api/generate.ts
+++ b/api/generate.ts
@@ -12,6 +12,84 @@ const MAX_CONTENTS_LENGTH = 100_000;
 /** Models the proxy is allowed to forward to. */
 const ALLOWED_MODEL_PREFIXES = ['gemini-'];
 
+/**
+ * Exhaustive allowlist of SDK GenerateContentConfig keys the client is
+ * permitted to set. Any key not in this list is silently dropped before
+ * the config object is forwarded to the Gemini SDK.
+ *
+ * Rationale: the `config` field is an open Record<string, unknown> on the
+ * wire. Without filtering, a caller could inject SDK-level overrides such as
+ * `systemInstruction`, `safetySettings`, `tools`, `toolConfig`, or
+ * `cachedContent` — bypassing the prompt-level constraints enforced by the
+ * server and potentially altering model behaviour in unintended ways.
+ */
+const ALLOWED_CONFIG_KEYS = new Set([
+  'temperature',
+  'topP',
+  'topK',
+  'maxOutputTokens',
+  'stopSequences',
+  'candidateCount',
+  'presencePenalty',
+  'frequencyPenalty',
+  'seed',
+  'responseMimeType',
+] as const);
+
+type SanitizedConfig = {
+  temperature?: number;
+  topP?: number;
+  topK?: number;
+  maxOutputTokens?: number;
+  stopSequences?: string[];
+  candidateCount?: number;
+  presencePenalty?: number;
+  frequencyPenalty?: number;
+  seed?: number;
+  responseMimeType?: string;
+};
+
+/**
+ * Strips any key not in ALLOWED_CONFIG_KEYS and validates primitive types.
+ * Non-conforming values are dropped silently — we never reflect raw
+ * client-supplied error details back in the response.
+ */
+function sanitizeConfig(raw: Record<string, unknown>): SanitizedConfig {
+  const out: SanitizedConfig = {};
+  for (const key of ALLOWED_CONFIG_KEYS) {
+    if (!(key in raw)) continue;
+    const val = raw[key];
+    switch (key) {
+      case 'temperature':
+      case 'topP':
+      case 'topK':
+      case 'maxOutputTokens':
+      case 'candidateCount':
+      case 'presencePenalty':
+      case 'frequencyPenalty':
+      case 'seed':
+        if (typeof val === 'number' && isFinite(val)) {
+          (out as Record<string, unknown>)[key] = val;
+        }
+        break;
+      case 'stopSequences':
+        if (
+          Array.isArray(val) &&
+          val.every((s): s is string => typeof s === 'string')
+        ) {
+          out.stopSequences = val;
+        }
+        break;
+      case 'responseMimeType':
+        if (typeof val === 'string') {
+          out.responseMimeType = val;
+        }
+        break;
+    }
+  }
+  return out;
+}
+
 export default async function handler(req: VercelRequest, res: VercelResponse) {
   if (req.method !== 'POST') {
     res.status(405).json({ error: 'Method Not Allowed' });
@@ -63,6 +141,13 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
       return;
     }
 
+    // Sanitize the config object: only allowed keys with validated types pass
+    // through. abortSignal is injected server-side and must never come from
+    // the client.
+    const sanitizedConfig = config != null && typeof config === 'object'
+      ? sanitizeConfig(config)
+      : {};
+
     const ai = new GoogleGenAI({ apiKey });
     const controller = new AbortController();
     const timer = setTimeout(() => controller.abort(), GEMINI_TIMEOUT_MS);
@@ -72,7 +157,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
       response = await ai.models.generateContent({
         model,
         contents,
-        config: { ...config, abortSignal: controller.signal },
+        config: { ...sanitizedConfig, abortSignal: controller.signal },
       });
     } finally {
       clearTimeout(timer);

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "lyricist-pro",
   "private": true,
-  "version": "3.21.5",
+  "version": "3.21.6",
   "type": "module",
   "scripts": {
     "dev": "vite --port=3000 --host=0.0.0.0",


### PR DESCRIPTION
## Périmètre

PR-1 du plan d'audit LYRICIST — impact sécurité, risque régression faible.

## Finding adressé : [SEC-1] Injection de paramètres SDK arbitraires via `config`

### Problème

`api/generate.ts` effectuait un spread direct du champ `config` reçu du client vers `GoogleGenAI.generateContent()` :

```ts
// AVANT — config client spreaded sans filtrage
config: { ...config, abortSignal: controller.signal }
```

Un attaquant pouvait injecter n'importe quelle clé de `GenerateContentConfig` du SDK Gemini :
- `systemInstruction` → remplacement du system prompt serveur
- `safetySettings` → désactivation des filtres de contenu
- `tools` / `toolConfig` → activation de function calling non intentionnel
- `cachedContent` → contournement du contexte de génération

### Correctif

Introduction d'une fonction `sanitizeConfig()` avec une allowlist explicite de 10 clés :

```ts
const ALLOWED_CONFIG_KEYS = new Set([
  'temperature', 'topP', 'topK', 'maxOutputTokens',
  'stopSequences', 'candidateCount', 'presencePenalty',
  'frequencyPenalty', 'seed', 'responseMimeType',
]);
```

Chaque valeur est validée par type primitif (number fini, string[], string). Les clés inconnues ou à type invalide sont **silencieusement éliminées** — aucun détail d'erreur interne n'est reflété vers le client.

`abortSignal` reste injecté serveur-side exclusivement et ne figure pas dans l'allowlist.

## Risque régression

Aucun : les clients légitimes n'envoient que `temperature`, `maxOutputTokens`, et `responseMimeType`. Le comportement nominal est inchangé.

## Version

`3.21.5` → `3.21.6`