### PR TITLE
fix(stability): ErrorBoundary coverage on InsightsBar + LyricsView + getDerivedStateFromError — v3.25.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "vibe",
   "private": true,
-  "version": "3.25.3",
+  "version": "3.25.4",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/components/app/AppEditorZone.tsx
+++ b/src/components/app/AppEditorZone.tsx
@@ -3,6 +3,9 @@
  * Renders the central content area: InsightsBar (conditional) + the scrollable
  * lyrics/musical zone. Receives only the props it cannot source from contexts
  * to avoid re-wiring everything that is already context-available downstream.
+ *
+ * Each major zone (InsightsBar, LyricsView, MusicalTab) is wrapped in its own
+ * <ErrorBoundary> so a crash in one zone never takes down the others.
  */
 import React, { Suspense, lazy } from 'react';
 import { Spinner } from '@fluentui/react-components';
@@ -96,19 +99,21 @@ export function AppEditorZone({
   return (
     <>
       {activeTab === 'lyrics' && songHasContent && (
-        <InsightsBar
-          targetLanguage={targetLanguage} setTargetLanguage={setTargetLanguage}
-          isAdaptingLanguage={isAdaptingLanguage} isDetectingLanguage={isDetectingLanguage}
-          isAnalyzing={isAnalyzing}
-          editMode={editMode} switchEditMode={switchEditMode}
-          webSimilarityIndex={webSimilarityIndex}
-          webBadgeLabel={webBadgeLabel}
-          libraryCount={libraryCount} adaptSongLanguage={adaptSongLanguage}
-          detectLanguage={detectLanguage} analyzeCurrentSong={analyzeCurrentSong}
-          setIsSimilarityModalOpen={setIsSimilarityModalOpen}
-          adaptationProgress={adaptationProgress} adaptationResult={adaptationResult}
-          showTranslationFeatures={showTranslationFeatures}
-        />
+        <ErrorBoundary label="Insights">
+          <InsightsBar
+            targetLanguage={targetLanguage} setTargetLanguage={setTargetLanguage}
+            isAdaptingLanguage={isAdaptingLanguage} isDetectingLanguage={isDetectingLanguage}
+            isAnalyzing={isAnalyzing}
+            editMode={editMode} switchEditMode={switchEditMode}
+            webSimilarityIndex={webSimilarityIndex}
+            webBadgeLabel={webBadgeLabel}
+            libraryCount={libraryCount} adaptSongLanguage={adaptSongLanguage}
+            detectLanguage={detectLanguage} analyzeCurrentSong={analyzeCurrentSong}
+            setIsSimilarityModalOpen={setIsSimilarityModalOpen}
+            adaptationProgress={adaptationProgress} adaptationResult={adaptationResult}
+            showTranslationFeatures={showTranslationFeatures}
+          />
+        </ErrorBoundary>
       )}
 
       <div
@@ -120,31 +125,33 @@ export function AppEditorZone({
         <div className="lyrics-editor-zoom-wrapper">
           <div className="lyrics-editor-zoom">
             {activeTab === 'lyrics' ? (
-              <LyricsView
-                isAnalyzing={isAnalyzing}
-                isAdaptingLanguage={isAdaptingLanguage}
-                sectionTargetLanguages={sectionTargetLanguages}
-                onSectionTargetLanguageChange={onSectionTargetLanguageChange}
-                adaptSectionLanguage={adaptSectionLanguage}
-                adaptLineLanguage={adaptLineLanguage}
-                adaptingLineIds={adaptingLineIds}
-                playAudioFeedback={playAudioFeedback}
-                handleDrop={handleDrop}
-                handleLineDragStart={handleLineDragStart}
-                handleLineDrop={handleLineDrop}
-                editMode={editMode} setEditMode={setEditMode}
-                markupText={markupText} setMarkupText={setMarkupText}
-                markupTextareaRef={markupTextareaRef}
-                markupDirection={markupDirection}
-                canPasteLyrics={canPasteLyrics}
-                targetLanguage={targetLanguage}
-                onOpenLibrary={onOpenLibrary}
-                onPasteLyrics={onPasteLyrics}
-                onGenerateSong={onGenerateSong}
-                showTranslationFeatures={showTranslationFeatures}
-              />
+              <ErrorBoundary label="Lyrics editor">
+                <LyricsView
+                  isAnalyzing={isAnalyzing}
+                  isAdaptingLanguage={isAdaptingLanguage}
+                  sectionTargetLanguages={sectionTargetLanguages}
+                  onSectionTargetLanguageChange={onSectionTargetLanguageChange}
+                  adaptSectionLanguage={adaptSectionLanguage}
+                  adaptLineLanguage={adaptLineLanguage}
+                  adaptingLineIds={adaptingLineIds}
+                  playAudioFeedback={playAudioFeedback}
+                  handleDrop={handleDrop}
+                  handleLineDragStart={handleLineDragStart}
+                  handleLineDrop={handleLineDrop}
+                  editMode={editMode} setEditMode={setEditMode}
+                  markupText={markupText} setMarkupText={setMarkupText}
+                  markupTextareaRef={markupTextareaRef}
+                  markupDirection={markupDirection}
+                  canPasteLyrics={canPasteLyrics}
+                  targetLanguage={targetLanguage}
+                  onOpenLibrary={onOpenLibrary}
+                  onPasteLyrics={onPasteLyrics}
+                  onGenerateSong={onGenerateSong}
+                  showTranslationFeatures={showTranslationFeatures}
+                />
+              </ErrorBoundary>
             ) : (
-              <ErrorBoundary>
+              <ErrorBoundary label="Musical tab">
                 <Suspense fallback={<LazyFallback />}>
                   <MusicalTab hasApiKey={hasApiKey} />
                 </Suspense>

--- a/src/components/app/ErrorBoundary.tsx
+++ b/src/components/app/ErrorBoundary.tsx
@@ -2,6 +2,8 @@ import React, { Component, type ReactNode, type ErrorInfo } from 'react';
 
 interface Props {
   children: ReactNode;
+  /** Optional label shown in the fallback header (for scoped boundaries). */
+  label?: string;
 }
 
 interface State {
@@ -12,13 +14,24 @@ interface State {
 export class ErrorBoundary extends Component<Props, State> {
   state: State = { error: null, errorInfo: null };
 
+  /**
+   * getDerivedStateFromError ensures the error state is committed during the
+   * render phase itself, so React never attempts to re-render the crashing
+   * subtree before switching to the fallback UI.
+   */
+  static getDerivedStateFromError(error: Error): Partial<State> {
+    return { error };
+  }
+
   componentDidCatch(error: Error, errorInfo: ErrorInfo) {
-    this.setState({ error, errorInfo });
+    // Capture errorInfo (component stack) which is only available here.
+    this.setState({ errorInfo });
     console.error('[ErrorBoundary] Uncaught error:', error, errorInfo);
   }
 
   render() {
     const { error, errorInfo } = this.state;
+    const { label } = this.props;
     if (!error) return this.props.children;
 
     const isDev = import.meta.env.DEV;
@@ -32,13 +45,13 @@ export class ErrorBoundary extends Component<Props, State> {
           padding: '2rem',
           background: '#0a0a0a',
           color: '#f87171',
-          minHeight: '100dvh',
+          minHeight: label ? undefined : '100dvh',
           boxSizing: 'border-box',
           overflowY: 'auto',
         }}
       >
         <div style={{ fontSize: '1.1rem', fontWeight: 700, marginBottom: '0.5rem' }}>
-          ⚠ Application error
+          ⚠ {label ? `${label} error` : 'Application error'}
         </div>
         <div style={{ color: '#fca5a5', marginBottom: '1rem' }}>
           {error.message}


### PR DESCRIPTION
## PR-1 — Stabilité critique : couverture ErrorBoundary

### Contexte
Analyse exhaustive du 29 mars 2026 — findings de priorité 🔴 Critique.

### Problèmes adressés

**1. Absence d'ErrorBoundary sur InsightsBar et LyricsView**  
Les deux zones les plus volumineuses et actives de l'application (21 KB et 19 KB respectivement, avec moteur AI, drag-and-drop, similarity engine) n'étaient pas protégées. Une exception non catchée dans l'une d'elles crashait l'application entière sans aucun fallback UI.

**2. `getDerivedStateFromError` absent dans ErrorBoundary**  
Sans cette méthode statique, React tentait un re-render du sous-arbre crashé avant de commuter sur le fallback, pouvant générer des erreurs secondaires en cascade. Seul `componentDidCatch` était implémenté — correct pour le logging, insuffisant pour la commutation d'état.

### Changements

| Fichier | Modification |
|---|---|
| `src/components/app/ErrorBoundary.tsx` | Ajout de `static getDerivedStateFromError` ; ajout prop optionnelle `label` pour identifier la zone dans le fallback UI |
| `src/components/app/AppEditorZone.tsx` | Wrapping `<InsightsBar>`, `<LyricsView>` et `<MusicalTab>` chacun dans leur propre `<ErrorBoundary label="...">` — isolation totale des zones |
| `package.json` | Version `3.25.3` → `3.25.4` |

### Comportement post-merge
- Un crash dans InsightsBar affiche un fallback `⚠ Insights error` localisé sans toucher LyricsView ni MusicalTab
- Un crash dans LyricsView affiche `⚠ Lyrics editor error` sans affecter la toolbar
- Le fallback `minHeight: 100dvh` ne s'applique qu'en l'absence de `label` (cas root-level)

### Régression
Aucune : les chemins sans erreur sont structurellement identiques. Les `ErrorBoundary` n'interceptent que les exceptions React.

### Suite (PRs suivantes)
- PR-2 : split `AppStateContext` en contextes atomiques (re-renders en cascade)
- PR-3 : split `useSessionState` en 4 hooks domaine
- PR-4 : mémoïsation `textFingerprint` + import type inline dans `useSimilarityEngine`