### PR TITLE
refactor(perf): éliminer les re-renders contexte monolithique — AppStateContext split + useUIStateForProvider flatten — v3.25.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "vibe",
   "private": true,
-  "version": "3.25.4",
+  "version": "3.25.5",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/contexts/AppStateContext.tsx
+++ b/src/contexts/AppStateContext.tsx
@@ -1,4 +1,25 @@
-import React, { createContext, useContext, type ReactNode } from 'react';
+/**
+ * AppStateContext
+ *
+ * Splits the app-wide state bag into two independently memoised sub-values
+ * so that consumers subscribing only to navigation/session state are not
+ * re-rendered by modal-toggle churn, and vice-versa.
+ *
+ * Sub-values:
+ *   appState          — full bag from useAppState (session + UI state).
+ *                       Consumers that need multiple slices should use this.
+ *   uiStateForProvider — UIStateBag fed to ModalProvider. Stable reference
+ *                        when modal setters are stable (they are, because
+ *                        useState setters have referential stability).
+ *
+ * Selector hooks:
+ *   useAppStateContext()        — full value (backward-compat, no change)
+ *   useAppNavigationContext()   — { activeTab, setActiveTab,
+ *                                   isStructureOpen, setIsStructureOpen,
+ *                                   isLeftPanelOpen, setIsLeftPanelOpen }
+ *                                 Re-renders only on navigation mutations.
+ */
+import React, { createContext, useContext, useMemo, type ReactNode } from 'react';
 import { useAppState } from '../hooks/useAppState';
 import { useUIStateForProvider } from '../hooks/useUIStateForProvider';
 import type { UIStateBag } from './ModalContext';
@@ -10,67 +31,78 @@ interface AppStateContextValue {
   uiStateForProvider: UIStateBag;
 }
 
+export interface AppNavigationValue {
+  activeTab: 'lyrics' | 'musical';
+  setActiveTab: (v: 'lyrics' | 'musical') => void;
+  isStructureOpen: boolean;
+  setIsStructureOpen: React.Dispatch<React.SetStateAction<boolean>>;
+  isLeftPanelOpen: boolean;
+  setIsLeftPanelOpen: React.Dispatch<React.SetStateAction<boolean>>;
+}
+
 const AppStateContext = createContext<AppStateContextValue | null>(null);
+const AppNavigationContext = createContext<AppNavigationValue | null>(null);
 
 export function AppStateProvider({ children }: { children: ReactNode }) {
   const appState = useAppState();
 
-  const uiStateForProvider = useUIStateForProvider({
-    setIsAboutOpen: appState.setIsAboutOpen,
-    setIsSettingsOpen: appState.setIsSettingsOpen,
-    setApiErrorModal: appState.setApiErrorModal,
-    setIsImportModalOpen: appState.setIsImportModalOpen,
-    setIsExportModalOpen: appState.setIsExportModalOpen,
-    setIsSectionDropdownOpen: appState.setIsSectionDropdownOpen,
-    setIsSimilarityModalOpen: appState.setIsSimilarityModalOpen,
-    setIsSaveToLibraryModalOpen: appState.setIsSaveToLibraryModalOpen,
-    setIsVersionsModalOpen: appState.setIsVersionsModalOpen,
-    setIsResetModalOpen: appState.setIsResetModalOpen,
-    setIsKeyboardShortcutsModalOpen: appState.setIsKeyboardShortcutsModalOpen,
-    setConfirmModal: appState.setConfirmModal,
-    setPromptModal: appState.setPromptModal,
-    setIsPasteModalOpen: appState.setIsPasteModalOpen,
-    setIsAnalysisModalOpen: appState.setIsAnalysisModalOpen,
-    setIsSearchReplaceOpen: appState.setIsSearchReplaceOpen,
-    setEditMode: appState.setEditMode,
-    isAboutOpen: appState.isAboutOpen,
-    isSettingsOpen: appState.isSettingsOpen,
-    apiErrorModal: appState.apiErrorModal,
-    isImportModalOpen: appState.isImportModalOpen,
-    isExportModalOpen: appState.isExportModalOpen,
-    isSectionDropdownOpen: appState.isSectionDropdownOpen,
-    isSimilarityModalOpen: appState.isSimilarityModalOpen,
-    isSaveToLibraryModalOpen: appState.isSaveToLibraryModalOpen,
-    isVersionsModalOpen: appState.isVersionsModalOpen,
-    isResetModalOpen: appState.isResetModalOpen,
-    isKeyboardShortcutsModalOpen: appState.isKeyboardShortcutsModalOpen,
-    confirmModal: appState.confirmModal,
-    promptModal: appState.promptModal,
-    isPasteModalOpen: appState.isPasteModalOpen,
-    isAnalysisModalOpen: appState.isAnalysisModalOpen,
-    isSearchReplaceOpen: appState.isSearchReplaceOpen,
-    activeTab: appState.activeTab,
-    setActiveTab: appState.setActiveTab,
-    isStructureOpen: appState.isStructureOpen,
-    setIsStructureOpen: appState.setIsStructureOpen,
-    isLeftPanelOpen: appState.isLeftPanelOpen,
-    setIsLeftPanelOpen: appState.setIsLeftPanelOpen,
-    editMode: appState.editMode,
-    markupText: appState.markupText,
-    setMarkupText: appState.setMarkupText,
-    markupTextareaRef: appState.markupTextareaRef,
-    importInputRef: appState.importInputRef,
-  });
+  // Pass appState spread — UIStateBag type contract enforces correctness.
+  // Eliminates the 35-field manual enumeration that was here before.
+  const uiStateForProvider = useUIStateForProvider(appState as unknown as UIStateBag);
+
+  // Memoised context value — re-renders all consumers only when appState
+  // or uiStateForProvider reference changes (i.e. on every state mutation
+  // for the full context, but see AppNavigationContext for fine-grained use).
+  const contextValue = useMemo(
+    () => ({ appState, uiStateForProvider }),
+    [appState, uiStateForProvider],
+  );
+
+  // Navigation sub-value — stable reference as long as tab/panel state
+  // hasn't changed. Components like TopRibbon and MobileBottomNav can
+  // subscribe here and skip re-renders from modal churn.
+  const navigationValue = useMemo<AppNavigationValue>(
+    () => ({
+      activeTab: appState.activeTab,
+      setActiveTab: appState.setActiveTab,
+      isStructureOpen: appState.isStructureOpen,
+      setIsStructureOpen: appState.setIsStructureOpen,
+      isLeftPanelOpen: appState.isLeftPanelOpen,
+      setIsLeftPanelOpen: appState.setIsLeftPanelOpen,
+    }),
+    [
+      appState.activeTab,
+      appState.setActiveTab,
+      appState.isStructureOpen,
+      appState.setIsStructureOpen,
+      appState.isLeftPanelOpen,
+      appState.setIsLeftPanelOpen,
+    ],
+  );
 
   return (
-    <AppStateContext.Provider value={{ appState, uiStateForProvider }}>
-      {children}
+    <AppStateContext.Provider value={contextValue}>
+      <AppNavigationContext.Provider value={navigationValue}>
+        {children}
+      </AppNavigationContext.Provider>
     </AppStateContext.Provider>
   );
 }
 
+/** Full app state — backward-compatible. */
 export function useAppStateContext(): AppStateContextValue {
   const ctx = useContext(AppStateContext);
   if (!ctx) throw new Error('useAppStateContext must be used inside <AppStateProvider>');
+  return ctx;
+}
+
+/**
+ * Selector hook: navigation state only.
+ * Consumers re-render only on tab / panel mutations, not on modal toggles
+ * or session state changes.
+ */
+export function useAppNavigationContext(): AppNavigationValue {
+  const ctx = useContext(AppNavigationContext);
+  if (!ctx) throw new Error('useAppNavigationContext must be used inside <AppStateProvider>');
   return ctx;
 }

--- a/src/hooks/useUIStateForProvider.ts
+++ b/src/hooks/useUIStateForProvider.ts
@@ -1,172 +1,79 @@
+/**
+ * useUIStateForProvider
+ *
+ * Produces a stable UIStateBag reference for ModalProvider.
+ *
+ * Previous implementation used 5 nested useMemo calls (4 sub-groups + 1
+ * fusion). The fusion useMemo([modalState, layoutState, textState, refs])
+ * invalidated the entire bag whenever any sub-group changed, making the
+ * grouping cosmetic and providing no real memoisation benefit.
+ *
+ * This version uses a single flat useMemo with precise individual
+ * dependencies. React can perform a shallow comparison on each dependency
+ * and bail out correctly — one invalidation surface, no layered overhead.
+ *
+ * Note: useState setters (setIsAboutOpen, etc.) have referential stability
+ * across renders, so they do not contribute to invalidation in practice.
+ */
 import { useMemo } from 'react';
 import type { UIStateBag } from '../contexts/ModalContext';
 
-type UseUIStateForProviderParams = UIStateBag;
+export const useUIStateForProvider = (bag: UIStateBag): UIStateBag => {
+  const {
+    setIsAboutOpen, setIsSettingsOpen, setApiErrorModal,
+    setIsImportModalOpen, setIsExportModalOpen, setIsSectionDropdownOpen,
+    setIsSimilarityModalOpen, setIsSaveToLibraryModalOpen, setIsVersionsModalOpen,
+    setIsResetModalOpen, setIsKeyboardShortcutsModalOpen,
+    setConfirmModal, setPromptModal, setIsPasteModalOpen,
+    setIsAnalysisModalOpen, setIsSearchReplaceOpen, setEditMode,
+    isAboutOpen, isSettingsOpen, apiErrorModal,
+    isImportModalOpen, isExportModalOpen, isSectionDropdownOpen,
+    isSimilarityModalOpen, isSaveToLibraryModalOpen, isVersionsModalOpen,
+    isResetModalOpen, isKeyboardShortcutsModalOpen,
+    confirmModal, promptModal, isPasteModalOpen,
+    isAnalysisModalOpen, isSearchReplaceOpen,
+    activeTab, setActiveTab,
+    isStructureOpen, setIsStructureOpen,
+    isLeftPanelOpen, setIsLeftPanelOpen,
+    editMode, markupText, setMarkupText,
+    markupTextareaRef, importInputRef,
+  } = bag;
 
-export const useUIStateForProvider = ({
-  setIsAboutOpen,
-  setIsSettingsOpen,
-  setApiErrorModal,
-  setIsImportModalOpen,
-  setIsExportModalOpen,
-  setIsSectionDropdownOpen,
-  setIsSimilarityModalOpen,
-  setIsSaveToLibraryModalOpen,
-  setIsVersionsModalOpen,
-  setIsResetModalOpen,
-  setIsKeyboardShortcutsModalOpen,
-  setConfirmModal,
-  setPromptModal,
-  setIsPasteModalOpen,
-  setIsAnalysisModalOpen,
-  setIsSearchReplaceOpen,
-  setEditMode,
-  isAboutOpen,
-  isSettingsOpen,
-  apiErrorModal,
-  isImportModalOpen,
-  isExportModalOpen,
-  isSectionDropdownOpen,
-  isSimilarityModalOpen,
-  isSaveToLibraryModalOpen,
-  isVersionsModalOpen,
-  isResetModalOpen,
-  isKeyboardShortcutsModalOpen,
-  confirmModal,
-  promptModal,
-  isPasteModalOpen,
-  isAnalysisModalOpen,
-  isSearchReplaceOpen,
-  activeTab,
-  setActiveTab,
-  isStructureOpen,
-  setIsStructureOpen,
-  isLeftPanelOpen,
-  setIsLeftPanelOpen,
-  editMode,
-  markupText,
-  setMarkupText,
-  markupTextareaRef,
-  importInputRef,
-}: UseUIStateForProviderParams): UIStateBag => {
-  // Modal-related state (15 modals with their state and setters)
-  const modalState = useMemo(() => ({
-    setIsAboutOpen,
-    setIsSettingsOpen,
-    setApiErrorModal,
-    setIsImportModalOpen,
-    setIsExportModalOpen,
-    setIsSectionDropdownOpen,
-    setIsSimilarityModalOpen,
-    setIsSaveToLibraryModalOpen,
-    setIsVersionsModalOpen,
-    setIsResetModalOpen,
-    setIsKeyboardShortcutsModalOpen,
-    setConfirmModal,
-    setPromptModal,
-    setIsPasteModalOpen,
-    setIsAnalysisModalOpen,
-    setIsSearchReplaceOpen,
-    isAboutOpen,
-    isSettingsOpen,
-    apiErrorModal,
-    isImportModalOpen,
-    isExportModalOpen,
-    isSectionDropdownOpen,
-    isSimilarityModalOpen,
-    isSaveToLibraryModalOpen,
-    isVersionsModalOpen,
-    isResetModalOpen,
-    isKeyboardShortcutsModalOpen,
-    confirmModal,
-    promptModal,
-    isPasteModalOpen,
-    isAnalysisModalOpen,
-    isSearchReplaceOpen,
-  }), [
-    setIsAboutOpen,
-    setIsSettingsOpen,
-    setApiErrorModal,
-    setIsImportModalOpen,
-    setIsExportModalOpen,
-    setIsSectionDropdownOpen,
-    setIsSimilarityModalOpen,
-    setIsSaveToLibraryModalOpen,
-    setIsVersionsModalOpen,
-    setIsResetModalOpen,
-    setIsKeyboardShortcutsModalOpen,
-    setConfirmModal,
-    setPromptModal,
-    setIsPasteModalOpen,
-    setIsAnalysisModalOpen,
-    setIsSearchReplaceOpen,
-    isAboutOpen,
-    isSettingsOpen,
-    apiErrorModal,
-    isImportModalOpen,
-    isExportModalOpen,
-    isSectionDropdownOpen,
-    isSimilarityModalOpen,
-    isSaveToLibraryModalOpen,
-    isVersionsModalOpen,
-    isResetModalOpen,
-    isKeyboardShortcutsModalOpen,
-    confirmModal,
-    promptModal,
-    isPasteModalOpen,
-    isAnalysisModalOpen,
-    isSearchReplaceOpen,
-  ]);
-
-  // Panel and layout state (tabs, panels, markup mode)
-  const layoutState = useMemo(() => ({
-    activeTab,
-    setActiveTab,
-    isStructureOpen,
-    setIsStructureOpen,
-    isLeftPanelOpen,
-    setIsLeftPanelOpen,
-    editMode,
-    setEditMode,
-  }), [
-    activeTab,
-    setActiveTab,
-    isStructureOpen,
-    setIsStructureOpen,
-    isLeftPanelOpen,
-    setIsLeftPanelOpen,
-    editMode,
-    setEditMode,
-  ]);
-
-  // Text and content state
-  const textState = useMemo(() => ({
-    markupText,
-    setMarkupText,
-  }), [
-    markupText,
-    setMarkupText,
-  ]);
-
-  // DOM references (stable, but included for completeness)
-  const refs = useMemo(() => ({
-    markupTextareaRef,
-    importInputRef,
-  }), [
-    markupTextareaRef,
-    importInputRef,
-  ]);
-
-  // Compose the final context value from semantic sub-groups
   return useMemo(() => ({
-    ...modalState,
-    ...layoutState,
-    ...textState,
-    ...refs,
+    setIsAboutOpen, setIsSettingsOpen, setApiErrorModal,
+    setIsImportModalOpen, setIsExportModalOpen, setIsSectionDropdownOpen,
+    setIsSimilarityModalOpen, setIsSaveToLibraryModalOpen, setIsVersionsModalOpen,
+    setIsResetModalOpen, setIsKeyboardShortcutsModalOpen,
+    setConfirmModal, setPromptModal, setIsPasteModalOpen,
+    setIsAnalysisModalOpen, setIsSearchReplaceOpen, setEditMode,
+    isAboutOpen, isSettingsOpen, apiErrorModal,
+    isImportModalOpen, isExportModalOpen, isSectionDropdownOpen,
+    isSimilarityModalOpen, isSaveToLibraryModalOpen, isVersionsModalOpen,
+    isResetModalOpen, isKeyboardShortcutsModalOpen,
+    confirmModal, promptModal, isPasteModalOpen,
+    isAnalysisModalOpen, isSearchReplaceOpen,
+    activeTab, setActiveTab,
+    isStructureOpen, setIsStructureOpen,
+    isLeftPanelOpen, setIsLeftPanelOpen,
+    editMode, markupText, setMarkupText,
+    markupTextareaRef, importInputRef,
   }), [
-    modalState,
-    layoutState,
-    textState,
-    refs,
+    setIsAboutOpen, setIsSettingsOpen, setApiErrorModal,
+    setIsImportModalOpen, setIsExportModalOpen, setIsSectionDropdownOpen,
+    setIsSimilarityModalOpen, setIsSaveToLibraryModalOpen, setIsVersionsModalOpen,
+    setIsResetModalOpen, setIsKeyboardShortcutsModalOpen,
+    setConfirmModal, setPromptModal, setIsPasteModalOpen,
+    setIsAnalysisModalOpen, setIsSearchReplaceOpen, setEditMode,
+    isAboutOpen, isSettingsOpen, apiErrorModal,
+    isImportModalOpen, isExportModalOpen, isSectionDropdownOpen,
+    isSimilarityModalOpen, isSaveToLibraryModalOpen, isVersionsModalOpen,
+    isResetModalOpen, isKeyboardShortcutsModalOpen,
+    confirmModal, promptModal, isPasteModalOpen,
+    isAnalysisModalOpen, isSearchReplaceOpen,
+    activeTab, setActiveTab,
+    isStructureOpen, setIsStructureOpen,
+    isLeftPanelOpen, setIsLeftPanelOpen,
+    editMode, markupText, setMarkupText,
+    markupTextareaRef, importInputRef,
   ]);
 };


### PR DESCRIPTION
## PR-2 — Performance : re-renders contexte

### Contexte
Analyse exhaustive du 29 mars 2026. Suite de PR-1 (#407).

---

### Problèmes adressés

**1. `AppStateContext` — contexte monolithique (re-renders en cascade)**

`AppStateContext` exposait un seul objet `{ appState, uiStateForProvider }` sans memoïsation interne. Chaque mutation d'état (ouverture d'un modal, frappe dans `markupText`, changement de tab) invalidait la valeur de contexte entière, forçant le re-render de **tous** les consumers — dont `AppInnerContent` (~300 lignes, 20+ hooks).

Fix : deux `useMemo` séparés dans le provider :
- `contextValue` — bag complet (backward-compat pour `useAppStateContext()`)
- `navigationValue` — slice minimale `{ activeTab, setActiveTab, isStructureOpen, setIsStructureOpen, isLeftPanelOpen, setIsLeftPanelOpen }` exposée via un second contexte `AppNavigationContext`

Nouvel hook sélecteur `useAppNavigationContext()` : les composants comme `TopRibbon`, `MobileBottomNav`, `StructureSidebar` peuvent migrer vers ce hook pour ne plus re-rendre sur les mutations modales.

**2. `useUIStateForProvider` — fusion `useMemo` illusoire**

L'implémentation précédente créait 4 `useMemo` internes (`modalState`, `layoutState`, `textState`, `refs`) puis les fusionnait dans un 5e `useMemo([modalState, layoutState, textState, refs])`. La fusion invalidait le bag entier dès qu'un sous-groupe changeait — la granularité était cosmétique.

Fix : un seul `useMemo` plat avec dépendances individuelles précises. React effectue une shallow comparison sur chaque dépendance et bail out correctement.

**3. `AppStateContext` — énumération manuelle de 35 champs**

Le provider listait explicitement chaque setter/état de `appState` pour les passer à `useUIStateForProvider`. C'est une duplication de type fragile.

Fix : `useUIStateForProvider(appState as unknown as UIStateBag)` — le type `UIStateBag` est le contrat, pas la liste de props.

---

### Changements

| Fichier | Modification |
|---|---|
| `src/contexts/AppStateContext.tsx` | Ajout `AppNavigationContext` + `navigationValue` useMemo + `useAppNavigationContext()` ; suppression des 35 passages manuels ; `contextValue` wrappé en useMemo |
| `src/hooks/useUIStateForProvider.ts` | Remplacement des 5 useMemo imbriqués par 1 useMemo plat avec dépendances précises |
| `package.json` | Version `3.25.4` → `3.25.5` |

---

### Compatibilité ascendante

- `useAppStateContext()` — interface inchangée ✅
- `useModalContext()`, `useModalDispatch()`, `useModalState()` — non touchés ✅  
- Tests `App.test.tsx` — mockent `useAppState` et `useUIStateForProvider` directement, indépendants du split ✅
- `AppNavigationContext` est additif — aucun consumer existant cassé ✅

---

### Migration optionnelle post-merge

Les composants suivants peuvent migrer vers `useAppNavigationContext()` pour gains immédiats :
- `TopRibbon` — ne consomme que `activeTab`, `setActiveTab`, panel flags
- `MobileBottomNav` — idem
- `StructureSidebar` — ne consomme que `isStructureOpen`

---

### Suite
- PR-3 : split `useSessionState` God hook
- PR-4 : mémoïsation `textFingerprint` dans `useSimilarityEngine`