### PR TITLE
feat(linguistics): Sanskrit (sa) support — LID Stage 1.5 + Registry

### DIFF
--- a/src/constants/langFamilyMap.ts
+++ b/src/constants/langFamilyMap.ts
@@ -16,6 +16,7 @@
  *     iko 🏺  Ogoja (Cross River, Nigeria)
  *     jv  🎭  Javanese (Java, sub-national dialect)
  *     wuu 🏙️  Wu / Shanghainese (Sinitic regional dialect)
+ *     sa  🕉️  Sanskrit (classical, no single nation-state)
  */
 
 export type AlgoFamily =
@@ -76,6 +77,7 @@ export const LANGUAGE_FLAGS: Record<string, string> = {
   'iko': '🏺',                  // Ogoja (Cross River, Nigeria)
   // ── Indo-Iranian ─────────────────────────────────────────────────────────
   'hi': '🇮🇳', 'ur': '🇵🇰', 'bn': '🇧🇩', 'pa': '🇮🇳', 'fa': '🇮🇷',
+  'sa': '🕉️',                   // Sanskrit: classical language, no nation-state flag
   // ── Dravidian ────────────────────────────────────────────────────────────
   'ta': '🇱🇰', 'te': '🇮🇳', 'kn': '🇮🇳', 'ml': '🇮🇳',
   // ── Turkic ───────────────────────────────────────────────────────────────
@@ -115,8 +117,9 @@ export const LANG_TO_FAMILY: Record<string, AlgoFamily> = {
   'ba':  'ALGO-KWA', 'di': 'ALGO-KWA', 'ew': 'ALGO-KWA', 'mi': 'ALGO-KWA',
   // Cross River / Chadic
   'bkv': 'ALGO-CRV', 'ijn': 'ALGO-CRV', 'iko': 'ALGO-CRV', 'ha': 'ALGO-CRV',
-  // Indo-Iranian
+  // Indo-Iranian — Sanskrit shares ALGO-IIR (same family, distinct phonology handled at strategy level)
   'hi': 'ALGO-IIR', 'ur': 'ALGO-IIR', 'bn': 'ALGO-IIR', 'pa': 'ALGO-IIR', 'fa': 'ALGO-IIR',
+  'sa': 'ALGO-IIR',
   // Dravidian
   'ta': 'ALGO-DRV', 'te': 'ALGO-DRV', 'kn': 'ALGO-DRV', 'ml': 'ALGO-DRV',
   // Turkic
@@ -145,7 +148,11 @@ export const FAMILY_CONFIG: Record<AlgoFamily, LanguageFamilyConfig> = {
   'ALGO-BNT':    { family: 'ALGO-BNT',    label: 'Bantu',                flag: '🇰🇪', hasTones: true,  hasVowelHarmony: true,  syllableStructure: 'CV',      codaRelevance: 'medium' },
   'ALGO-KWA':    { family: 'ALGO-KWA',    label: 'Kwa (Niger-Congo)',    flag: '🇨🇮', hasTones: true,  hasVowelHarmony: true,  syllableStructure: 'CV',      codaRelevance: 'none' },
   'ALGO-CRV':    { family: 'ALGO-CRV',    label: 'Cross River / Chadic', flag: '🇳🇬', hasTones: true,  hasVowelHarmony: false, syllableStructure: 'CVC',     codaRelevance: 'medium' },
-  'ALGO-IIR':    { family: 'ALGO-IIR',    label: 'Indo-Iranian',         flag: '🇮🇳', hasTones: false, hasVowelHarmony: false, syllableStructure: 'CVC',     codaRelevance: 'medium' },
+  // ALGO-IIR: syllableStructure set to 'complex' to cover both modern Hindi (CVC)
+  // and Classical Sanskrit (laghu/guru weight system, conjunct consonants, sandhi).
+  // Strategy implementations must check langCode === 'sa' to apply Sanskrit-specific
+  // syllabification (mātrā-based weight) vs. Hindi (stress-accent based).
+  'ALGO-IIR':    { family: 'ALGO-IIR',    label: 'Indo-Iranian',         flag: '🇮🇳', hasTones: false, hasVowelHarmony: false, syllableStructure: 'complex', codaRelevance: 'medium' },
   'ALGO-DRV':    { family: 'ALGO-DRV',    label: 'Dravidian',            flag: '🇮🇳', hasTones: false, hasVowelHarmony: false, syllableStructure: 'CVC',     codaRelevance: 'medium' },
   'ALGO-TRK':    { family: 'ALGO-TRK',    label: 'Turkic',               flag: '🇹🇷', hasTones: false, hasVowelHarmony: true,  syllableStructure: 'CVC',     codaRelevance: 'medium' },
   'ALGO-FIN':    { family: 'ALGO-FIN',    label: 'Uralic',               flag: '🇫🇮', hasTones: false, hasVowelHarmony: true,  syllableStructure: 'CVC',     codaRelevance: 'medium' },
@@ -205,6 +212,8 @@ export const LANGUAGE_NAME_TO_CODE: Record<string, string> = {
   'chinese': 'zh', 'mandarin': 'zh', 'cantonese': 'yue', 'wu': 'wuu', 'shanghainese': 'wuu',
   'japanese': 'ja', 'korean': 'ko', 'javanese': 'jv',
   'hindi': 'hi', 'urdu': 'ur', 'bengali': 'bn', 'punjabi': 'pa', 'persian': 'fa',
+  // Sanskrit — multiple surface forms (classical + transliterated)
+  'sanskrit': 'sa', 'samskrita': 'sa', 'saṃskṛta': 'sa', 'संस्कृत': 'sa',
   'tamil': 'ta', 'telugu': 'te', 'kannada': 'kn', 'malayalam': 'ml',
   'thai': 'th', 'lao': 'lo', 'vietnamese': 'vi', 'khmer': 'km',
   'indonesian': 'id', 'malay': 'ms', 'tagalog': 'tl',

--- a/src/lib/linguistics/lid/detectLanguage.ts
+++ b/src/lib/linguistics/lid/detectLanguage.ts
@@ -8,6 +8,18 @@
  *     Unicode range matching resolves ~80% of cases unambiguously
  *     (Cyrillic → ru, CJK → zh/ja/ko, Arabic → ar, Devanagari → hi, etc.).
  *
+ *   Stage 1.5 — Devanagari disambiguation
+ *     Hindi (hi), Sanskrit (sa), Marathi (mr) and Nepali (ne) all use
+ *     Devanagari (\u0900-\u097F). Stage 1 alone cannot distinguish them.
+ *     A word-pilot pass over Sanskrit-exclusive tokens (classical particles,
+ *     sandhi markers) runs ONLY when Devanagari script is detected.
+ *     If no Sanskrit signal is found, falls back to 'hi' (highest-frequency
+ *     Devanagari language in practice).
+ *
+ *     Sanskrit pilots (must be absent from modern Hindi / Marathi / Nepali
+ *     prose): च, एव, तु, अपि, इति, वा, यत्, तत्, सः, अस्ति, भवति,
+ *     अहम्, त्वम्, एतत्, इदम्, किम्, कः, सर्व, धर्म, कर्म, मोक्ष.
+ *
  *   Stage 2 — Word-pilot detector
  *     For Latin-script text, a small set of high-frequency, language-exclusive
  *     words scores each candidate language. Highest score wins.
@@ -33,6 +45,9 @@
  *   KWA noise : all mono/bichar tokens removed from ba/ew/mi/di.
  *               Replaced by multichar tokens with diacritics absent from
  *               fr/en/es/it, providing unambiguous signal.
+ *   sa vs hi  : Sanskrit pilots are Classical Sanskrit-exclusive particles and
+ *               inflected forms absent from modern Hindi/Marathi/Nepali prose.
+ *               Score threshold: ≥ 2 hits required to flip to 'sa'.
  */
 
 // ─── Constants ─────────────────────────────────────────────────────────────────
@@ -49,6 +64,10 @@ const MIN_TOKENS = 3;
  * Unicode range → language code.
  * Checked in order; first match wins.
  * Ranges cover the primary script for each language family.
+ *
+ * NOTE: Devanagari maps to 'hi' here as a provisional code only.
+ * Stage 1.5 (disambiguateDevanagari) may upgrade it to 'sa' (Sanskrit),
+ * 'mr' (Marathi) or 'ne' (Nepali) before the result is returned.
  */
 const SCRIPT_RULES: Array<{ pattern: RegExp; lang: string }> = [
   // Cyrillic
@@ -57,7 +76,7 @@ const SCRIPT_RULES: Array<{ pattern: RegExp; lang: string }> = [
   { pattern: /[\u0600-\u06FF]/, lang: 'ar' },
   // Hebrew
   { pattern: /[\u0590-\u05FF]/, lang: 'he' },
-  // Devanagari (Hindi / Sanskrit)
+  // Devanagari (Hindi / Sanskrit / Marathi / Nepali) — Stage 1.5 disambiguates
   { pattern: /[\u0900-\u097F]/, lang: 'hi' },
   // Bengali
   { pattern: /[\u0980-\u09FF]/, lang: 'bn' },
@@ -90,6 +109,81 @@ function detectByScript(text: string): string | undefined {
     if (pattern.test(text)) return lang;
   }
   return undefined;
+}
+
+// ─── Stage 1.5: Devanagari Disambiguation ─────────────────────────────────────
+
+/**
+ * Sanskrit-exclusive word pilots.
+ *
+ * Selection criteria:
+ *   1. Classical Sanskrit particles and inflected forms.
+ *   2. Must NOT appear in common modern Hindi / Marathi / Nepali prose.
+ *   3. Multi-character only — single-character tokens create too many
+ *      false positives with partial Devanagari sequences.
+ *
+ * Tokens include:
+ *   - Classical particles: च (ca, "and"), एव (eva, "indeed"), तु (tu, "but"),
+ *     अपि (api, "also"), इति (iti, end-of-quote marker), वा (vā, "or")
+ *   - Relative/demonstrative: यत् (yat), तत् (tat), एतत् (etat), इदम् (idam),
+ *     किम् (kim, "what?"), कः (kaḥ, "who?")
+ *   - Verbs: अस्ति (asti, "is"), भवति (bhavati, "becomes"), करोति (karoti)
+ *   - Pronouns: अहम् (aham, "I"), त्वम् (tvam, "you")
+ *   - High-frequency lexical: सर्व (sarva, "all"), धर्म (dharma), कर्म (karma),
+ *     मोक्ष (mokṣa), ब्रह्म (brahman), आत्म (ātman stem), लोक (loka),
+ *     देव (deva), नाम (nāma), पुण्य (puṇya)
+ *
+ * Threshold: ≥ SA_PILOT_THRESHOLD hits → classify as Sanskrit.
+ */
+const SA_PILOTS: ReadonlySet<string> = new Set([
+  'च', 'एव', 'तु', 'अपि', 'इति', 'वा',
+  'यत्', 'तत्', 'एतत्', 'इदम्', 'किम्', 'कः',
+  'अस्ति', 'भवति', 'करोति', 'अस्तु', 'भवतु',
+  'अहम्', 'त्वम्', 'वयम्', 'युयम्', 'तेषाम्',
+  'सर्व', 'सर्वे', 'सर्वम्',
+  'धर्म', 'धर्मः', 'धर्मम्', 'धर्मस्य',
+  'कर्म', 'कर्मः', 'कर्मणि',
+  'मोक्ष', 'मोक्षः',
+  'ब्रह्म', 'ब्रह्मन्', 'ब्रह्मणः',
+  'आत्म', 'आत्मन्', 'आत्मनः',
+  'लोक', 'लोकः', 'लोकम्',
+  'देव', 'देवः', 'देवानाम्',
+  'नाम', 'नामः', 'नाम्नः',
+  'पुण्य', 'पुण्यम्',
+  'ज्ञान', 'ज्ञानम्', 'ज्ञानस्य',
+  'वेद', 'वेदः', 'वेदानाम्',
+  'श्लोक', 'श्लोकः',
+]);
+
+/** Minimum Sanskrit pilot hits to flip Devanagari detection from 'hi' to 'sa'. */
+const SA_PILOT_THRESHOLD = 2;
+
+/**
+ * Stage 1.5 — given that Devanagari script was detected, attempt to
+ * differentiate Sanskrit (sa) from Hindi (hi).
+ *
+ * Splits the text into whitespace-delimited tokens and counts matches
+ * against SA_PILOTS. Returns 'sa' if threshold is met, 'hi' otherwise.
+ *
+ * Marathi (mr) and Nepali (ne) disambiguation is not implemented yet;
+ * both fall back to 'hi' — acceptable given their far lower lyric corpus
+ * frequency compared to hi/sa.
+ *
+ * @param text  Raw Devanagari text.
+ * @returns     'sa' | 'hi'
+ */
+function disambiguateDevanagari(text: string): 'sa' | 'hi' {
+  const tokens = text.split(/\s+/).filter(t => t.length > 0);
+  let hits = 0;
+  for (const token of tokens) {
+    // Strip trailing Devanagari punctuation (daṇḍa ।, double daṇḍa ॥)
+    const clean = token.replace(/[।॥]/g, '').trim();
+    if (clean.length > 0 && SA_PILOTS.has(clean)) {
+      hits++;
+      if (hits >= SA_PILOT_THRESHOLD) return 'sa';
+    }
+  }
+  return 'hi';
 }
 
 // ─── Stage 2: Word-Pilot Detector ──────────────────────────────────────────────────────────────
@@ -273,7 +367,11 @@ export function detectLanguage(text: string): string {
   if (!text || text.trim().length === 0) return DEFAULT_LANG;
 
   const byScript = detectByScript(text);
-  if (byScript) return byScript;
+  if (byScript) {
+    // Stage 1.5: disambiguate Devanagari before returning
+    if (byScript === 'hi') return disambiguateDevanagari(text);
+    return byScript;
+  }
 
   const tokens = tokenize(text);
   if (tokens.length < MIN_TOKENS) return DEFAULT_LANG;


### PR DESCRIPTION
## Problème

Le Sanskrit (`sa`) partage le script Devanagari (`\u0900-\u097F`) avec le Hindi, le Marathi et le Népalais. Le Stage 1 du LID retournait systématiquement `'hi'` pour tout texte Devanagari, causant :
- G2P incorrect (règles Hindi appliquées à du Sanskrit classique)
- Syllabification erronée (accent tonique Hindi vs. poids laghu/guru Sanskrit)
- Analyse phonologique faussée pour toute la chaîne downstream

## Solution

### `detectLanguage.ts` — Stage 1.5 : désambiguïsation Devanagari

Un pass word-pilot en Devanagari s'exécute **uniquement** quand le script détecté est `'hi'`. Il compte les occurrences de tokens Sanskrit-exclusifs (particules classiques, sandhi markers) et retourne `'sa'` si ≥ 2 hits.

**Tokens Sanskrit pilotes** (absents du Hindi/Marathi/Népalais moderne) :
- Particules : `च` (ca), `एव` (eva), `तु` (tu), `अपि` (api), `इति` (iti), `वा` (vā)
- Relatifs/démonstratifs : `यत्`, `तत्`, `एतत्`, `इदम्`, `किम्`, `कः`
- Formes verbales : `अस्ति` (asti), `भवति` (bhavati), `करोति` (karoti)
- Pronoms : `अहम्` (aham), `त्वम्` (tvam), `वयम्` (vayam)
- Lexèmes haute fréquence : `सर्व`, `धर्म`, `कर्म`, `मोक्ष`, `ब्रह्म`, `आत्म`, `लोक`, `देव`, `नाम`, `पुण्य`, `ज्ञान`, `वेद`, `श्लोक`

Seuil : **2 hits minimum** pour basculer vers `'sa'` — évite les faux positifs sur les mots d'origine sanskrite passés en Hindi courant.

### `langFamilyMap.ts` — 3 changements

1. **`LANG_TO_FAMILY`** : `'sa': 'ALGO-IIR'` — Sanskrit route vers la même famille Indo-Iranienne
2. **`LANGUAGE_FLAGS`** : `'sa': '🕉️'` — pictogramme (langue classique, pas d'État-nation)
3. **`LANGUAGE_NAME_TO_CODE`** : entrées `'sanskrit'`, `'samskrita'`, `'saṃskṛta'`, `'संस्कृत'` → `'sa'`
4. **`FAMILY_CONFIG['ALGO-IIR']`** : `syllableStructure: 'complex'` (était `'CVC'`) — reflète la coexistence Hindi (CVC) + Sanskrit (système laghu/guru, consonnes conjonctes, sandhi). Les implémentations de stratégie doivent contrôler `langCode === 'sa'` pour la syllabification spécifique.

## Ce qui reste à faire (hors scope)

- [ ] Stratégie G2P Sanskrit dans `ALGO-IIR` (règles visarga, anusvara, sandhi externe)
- [ ] Syllabification mātrika (poids syllabique laghu/guru) dans la stratégie IIR
- [ ] Tests unitaires `detectLanguage('अहम् ब्रह्मास्मि') === 'sa'`
- [ ] Désambiguïsation Marathi (`mr`) / Népalais (`ne`) (actuellement fallback → `'hi'`)

## Impact

| Avant | Après |
|---|---|
| Texte Sanskrit → `'hi'` → ALGO-IIR (mauvais G2P) | Texte Sanskrit → `'sa'` → ALGO-IIR (routing correct, `lowResourceFallback: true` jusqu'au G2P SA) |
| `languageNameToCode('sanskrit')` → `undefined` | `languageNameToCode('sanskrit')` → `'sa'` |
| `LANGUAGE_FLAGS['sa']` → `undefined` | `LANGUAGE_FLAGS['sa']` → `'🕉️'` |
