### PR TITLE
fix(rhyme): wire Step-0, langCode propagation, enjambment connectors,…

### DIFF
--- a/src/utils/rhymeDetection.ts
+++ b/src/utils/rhymeDetection.ts
@@ -41,48 +41,31 @@ const isVowel = (ch: string) => VOWELS.has(ch);
 /**
  * Strip Unicode accents and lowercase — with optional tonal preservation.
  * For tonal languages (KWA, CRV families), tone diacritics are preserved.
- * @param s - The string to normalize
- * @param langCode - Optional language code for tonal language detection
  */
 const normalizeWord = (s: string, langCode?: string): string => {
   const normalized = s.normalize('NFD');
-
   const stripDiacritics = isTonalLanguage(langCode || '')
     ? normalized
     : normalized.replace(/[\u0300-\u036f]/g, '');
-
   return stripDiacritics.toLowerCase().replace(/[^a-z\u0300-\u036f]/g, '');
 };
 
 /**
- * Extract the final word-like token from a lyric line, normalize it for
- * comparisons, and keep the original start offset so UI highlighting can be
- * mapped back onto the untouched line text.
- * @param text - The text to extract from
- * @param langCode - Optional language code for tonal preservation
+ * Extract the final word-like token from a lyric line.
  */
 const extractLastWord = (text: string, langCode?: string): WordMatch | null => {
   const trimmedText = text.trimEnd().replace(/[^\p{L}\p{N}]+$/u, '');
   if (!trimmedText) return null;
-
   const lastWordMatch = /[\p{L}\p{N}]+$/u.exec(trimmedText);
   if (!lastWordMatch) return null;
-
   const lastWord = lastWordMatch[0];
   const normalizedWord = normalizeWord(lastWord, langCode);
   if (!normalizedWord) return null;
-
-  return {
-    lastWord,
-    normalizedWord,
-    wordStart: lastWordMatch.index,
-  };
+  return { lastWord, normalizedWord, wordStart: lastWordMatch.index };
 };
 
 /**
- * Identify contiguous vowel groups inside a normalized word. These spans act
- * as the candidate starting points for rime comparisons and fallback splits.
- * Uses the extended IPA VOWELS set to correctly handle non-Latin families.
+ * Identify contiguous vowel groups inside a normalized word.
  */
 const getVowelGroups = (normalizedWord: string): VowelSpan[] => {
   const vowelGroups: VowelSpan[] = [];
@@ -101,24 +84,15 @@ const getVowelGroups = (normalizedWord: string): VowelSpan[] => {
 };
 
 /**
- * Keep short endings intact, but normalise common trailing plural markers on
- * longer endings so pairs like "certitudes"/"servitude" and
- * "possessifs"/"adjectif" can still converge on the same rime family.
- *
- * Canonical vowel-sequence substitutions (e.g. "an/en/am" → "an") are
- * Romance-specific orthographic conventions and are therefore gated on
- * ALGO-ROM. For all other families the raw suffix is returned as-is,
- * letting the IPA pipeline handle phonemic equivalence.
- *
- * When langCode is absent the Romance rules apply as a safe default,
- * preserving existing behaviour for callers that don't pass a language.
+ * Canonicalize rhyme suffix.
+ * Romance-specific orthographic rules are gated on ALGO-ROM.
+ * All other families return the raw suffix for IPA pipeline handling.
+ * When langCode is absent the Romance rules apply as a safe default.
  */
 const canonicalizeRhymeSuffix = (suffix: string, langCode?: string): string => {
   const s = suffix.length <= 3 ? suffix : suffix.replace(/[sx]$/, '');
-
   const family = langCode ? getAlgoFamily(langCode) : undefined;
   const isRomance = !family || family === 'ALGO-ROM';
-
   if (isRomance) {
     if (/^oi/.test(s)) return 'oi';
     if (/^(?:an|en|am|em)/.test(s)) return 'an';
@@ -129,62 +103,40 @@ const canonicalizeRhymeSuffix = (suffix: string, langCode?: string): string => {
     if (/^ou/.test(s)) return 'ou';
     if (/^(?:au|eau)/.test(s)) return 'au';
   }
-
   return s;
 };
 
 const getRhymeCandidates = (text: string, langCode?: string): RhymeCandidate[] => {
   const word = extractLastWord(text, langCode);
   if (!word) return [];
-
   const vowelGroups = getVowelGroups(word.normalizedWord);
   if (vowelGroups.length === 0) {
-    return [{
-      normalizedSuffix: canonicalizeRhymeSuffix(word.normalizedWord, langCode),
-    }];
+    return [{ normalizedSuffix: canonicalizeRhymeSuffix(word.normalizedWord, langCode) }];
   }
-
   return vowelGroups.map(({ start }) => ({
     normalizedSuffix: canonicalizeRhymeSuffix(word.normalizedWord.slice(start), langCode),
   }));
 };
 
-/**
- * Compare two normalized suffixes from right to left and return the longest
- * suffix they share verbatim.
- */
 const getLongestCommonSuffix = (a: string, b: string): string => {
   let sharedLength = 0;
   while (
-    sharedLength < a.length
-    && sharedLength < b.length
-    && a[a.length - 1 - sharedLength] === b[b.length - 1 - sharedLength]
+    sharedLength < a.length &&
+    sharedLength < b.length &&
+    a[a.length - 1 - sharedLength] === b[b.length - 1 - sharedLength]
   ) {
     sharedLength++;
   }
   return sharedLength > 0 ? a.slice(a.length - sharedLength) : '';
 };
 
-/**
- * Require at least 2 shared characters for general rhyme matching, but allow
- * exact one-vowel matches for short endings such as "zéro"/"ego" so we do not
- * discard valid monosyllabic vowel rhymes.
- */
 const isSharedRhymeStrongEnough = (suffix: string, exactMatch: boolean): boolean =>
   suffix.length >= 2 || (exactMatch && suffix.length === 1 && isVowel(suffix));
 
-/**
- * Compare every vowel-group-based candidate suffix from two lines and keep the
- * longest shared rime that is strong enough to count as an actual rhyme.
- * @param a - First line text
- * @param b - Second line text
- * @param langCode - Optional language code for tonal preservation
- */
 const findBestSharedRhymeSuffix = (a: string, b: string, langCode?: string): string | null => {
   const aCandidates = getRhymeCandidates(a, langCode);
   const bCandidates = getRhymeCandidates(b, langCode);
   let bestMatch = '';
-
   for (const aCandidate of aCandidates) {
     for (const bCandidate of bCandidates) {
       const exactMatch = aCandidate.normalizedSuffix === bCandidate.normalizedSuffix;
@@ -195,138 +147,62 @@ const findBestSharedRhymeSuffix = (a: string, b: string, langCode?: string): str
       if (sharedSuffix.length > bestMatch.length) bestMatch = sharedSuffix;
     }
   }
-
   return bestMatch || null;
 };
 
-/**
- * Known French vowel digraphs — two-vowel sequences representing a single
- * phoneme. "ie" is intentionally excluded because it is graphemically a
- * hiatus in most contexts (e.g. "miette" where i and e belong to separate
- * syllable nuclei).
- */
 const FRENCH_DIGRAPHS = new Set(['ai', 'ei', 'oi', 'ou', 'au', 'eu']);
 
-/**
- * Extend a shared-suffix position backward to include the preceding vowel
- * onset so the UI highlights complete French rimes rather than bare consonant
- * overlaps. For example, shared suffix "te" in "miette" extends to "ette",
- * and in "défaite" extends to "aite" (recognising "ai" as a diphthong).
- */
 const extendToVowelOnset = (normalizedWord: string, suffixStart: number): number => {
   if (suffixStart <= 0) return suffixStart;
-
   let pos = suffixStart;
-
   if (!isVowel(normalizedWord[pos]!)) {
     while (pos >= 0 && !isVowel(normalizedWord[pos]!)) pos--;
     if (pos < 0) return suffixStart;
   }
-
   if (pos >= 1 && isVowel(normalizedWord[pos - 1]!)) {
     const digraph = normalizedWord[pos - 1]! + normalizedWord[pos]!;
-    if (FRENCH_DIGRAPHS.has(digraph)) {
-      return pos - 1;
-    }
+    if (FRENCH_DIGRAPHS.has(digraph)) return pos - 1;
   }
-
   return pos;
 };
 
-/**
- * Split a line at the start of a normalized suffix found inside its last word,
- * preserving the original spelling and trailing punctuation in the rhyming
- * fragment returned to the UI overlay.
- *
- * For non-tonal languages the highlight is extended backward to include the
- * vowel onset preceding the shared consonant suffix, so that complete rhyming
- * syllables like "ette", "ête", "aite" are marked rather than just the bare
- * consonant overlap ("te").
- */
-const splitLineAtNormalizedSuffix = (text: string, normalizedSuffix: string, langCode?: string): { before: string; rhyme: string } | null => {
+const splitLineAtNormalizedSuffix = (
+  text: string,
+  normalizedSuffix: string,
+  langCode?: string,
+): { before: string; rhyme: string } | null => {
   const word = extractLastWord(text, langCode);
   if (!word) return null;
-
   const suffixStart = word.normalizedWord.lastIndexOf(normalizedSuffix);
   if (suffixStart < 0) return null;
-
   const effectiveStart = isTonalLanguage(langCode || '')
     ? suffixStart
     : extendToVowelOnset(word.normalizedWord, suffixStart);
-
   const absoluteStart = word.wordStart + effectiveStart;
-  return {
-    before: text.slice(0, absoluteStart),
-    rhyme: text.slice(absoluteStart),
-  };
+  return { before: text.slice(0, absoluteStart), rhyme: text.slice(absoluteStart) };
 };
 
-/**
- * When no matching peer line is available, fall back to highlighting from the
- * last vowel group of the word so the UI still marks a plausible rhyming tail.
- */
-const getFallbackRhymingSuffix = (text: string, langCode?: string): { before: string; rhyme: string } | null => {
+const getFallbackRhymingSuffix = (
+  text: string,
+  langCode?: string,
+): { before: string; rhyme: string } | null => {
   const word = extractLastWord(text, langCode);
   if (!word) return null;
-
   const vowelGroups = getVowelGroups(word.normalizedWord);
   if (vowelGroups.length === 0) {
-    return {
-      before: text.slice(0, word.wordStart),
-      rhyme: text.slice(word.wordStart),
-    };
+    return { before: text.slice(0, word.wordStart), rhyme: text.slice(word.wordStart) };
   }
-
-  return splitLineAtNormalizedSuffix(text, word.normalizedWord.slice(vowelGroups[vowelGroups.length - 1]!.start), langCode);
+  return splitLineAtNormalizedSuffix(
+    text,
+    word.normalizedWord.slice(vowelGroups[vowelGroups.length - 1]!.start),
+    langCode,
+  );
 };
-
-export const splitRhymingSuffix = (text: string, peerLines: string[] = [], langCode?: string): { before: string; rhyme: string } | null => {
-  let bestSuffix: string | null = null;
-
-  for (const peerLine of peerLines) {
-    const sharedSuffix = findBestSharedRhymeSuffix(text, peerLine, langCode);
-    if (sharedSuffix && (!bestSuffix || sharedSuffix.length > bestSuffix.length)) {
-      bestSuffix = sharedSuffix;
-    }
-  }
-
-  if (bestSuffix) {
-    const split = splitLineAtNormalizedSuffix(text, bestSuffix, langCode);
-    if (split) return split;
-  }
-
-  return getFallbackRhymingSuffix(text, langCode);
-};
-
-/**
- * Two lines rhyme when they share a strong enough rime suffix derived from
- * vowel-group candidates. This keeps scheme detection aligned with the same
- * rime logic used by the UI highlight overlay. Exact one-vowel matches are
- * allowed for short words such as "zéro" / "ego", while longer matches use a
- * suffix overlap.
- */
-export const doLinesRhymeGraphemic = (a: string, b: string, langCode?: string): boolean =>
-  findBestSharedRhymeSuffix(a, b, langCode) !== null;
 
 // ─── Step-0: verse segmentation ──────────────────────────────────────────────
 
-/**
- * Type of rhyme position within a line.
- * - 'end'      : classical end-of-line rhyme (default)
- * - 'internal' : rhyming unit found mid-line (caesura / internal rhyme)
- * - 'enjambed' : last token is syntactically incomplete (enjambement detected
- *                heuristically via trailing connector words)
- */
 export type RhymePosition = 'end' | 'internal' | 'enjambed';
 
-/**
- * Result of segmenting a verse line into its rhyming unit.
- * `rhymingUnit` is the normalized token passed to the IPA/graphemic pipeline.
- * `position` describes the structural role of that unit within the line.
- * `syllableIndex`, when present, indicates which syllable of the last word
- * carries the rhyme (0-based from the end, so 0 = final syllable). It is
- * only provided when a meaningful syllable-level rhyme position is known.
- */
 export type VerseRhymingSegment = {
   rhymingUnit: string;
   position: RhymePosition;
@@ -337,7 +213,13 @@ export type VerseRhymingSegment = {
 /**
  * Connector words that suggest a line is syntactically incomplete
  * (enjambement). Checked against the normalized last token.
- * Covers the most frequent Romance + Germanic cases.
+ *
+ * Covers:
+ * - Romance/Germanic (FR, EN, ES, IT, PT, DE, NL)
+ * - KWA (Baoulé, Dioula, Ewe, Mina)
+ * - BNT (Yoruba, Swahili, Zulu, Lingala)
+ * - CRV (Bekwarra, Ijaw)
+ * - CRE / Pidgin (Nouchi, Nigerian Pidgin)
  */
 const ENJAMBMENT_CONNECTORS = new Set([
   // French
@@ -347,153 +229,180 @@ const ENJAMBMENT_CONNECTORS = new Set([
   // English
   'and', 'or', 'but', 'so', 'yet', 'nor', 'for', 'the', 'a', 'an',
   'of', 'in', 'on', 'at', 'to', 'by', 'from', 'with', 'into', 'like',
+  // Spanish / Italian / Portuguese
+  'y', 'e', 'o', 'pero', 'sino', 'porque', 'que', 'con', 'sin', 'por',
+  // German / Dutch
+  'und', 'oder', 'aber', 'weil', 'mit', 'ohne', 'von', 'en', 'maar', 'van',
+  // Yoruba (ALGO-BNT)
+  'ati', 'àti', 'tabi', 'tàbí', 'nitori', 'bi', 'ti', 'ni', 'si', 'fun',
+  // Swahili (ALGO-BNT)
+  'na', 'ya', 'wa', 'za', 'la', 'kwa', 'bila', 'hadi', 'au',
+  // Dioula / Bambara (ALGO-KWA)
+  'ni', 'ka', 'ani', 'walima', 'nka', 'fo', 'kɔ',
+  // Baoulé (ALGO-KWA)
+  'mɔ', 'kɛ', 'yɛ',
+  // Ewe / Mina (ALGO-KWA)
+  'kple', 'eye', 'ke', 'ne', 'le',
+  // Lingala (ALGO-BNT)
+  'mpe', 'to', 'kasi', 'po', 'na',
+  // Nigerian Pidgin / Nouchi (ALGO-CRE)
+  'pis', 'kon', 'sof', 'den', 'dem', 'wit', 'fo',
+  // Bekwarra / Ijaw (ALGO-CRV)
+  'ma', 'be', 'ke',
 ]);
 
-/**
- * Families with agglutinative morphology where the last word of a line may
- * carry multiple candidate stress positions. For these families, we pick the
- * last stressed syllable (approximated as the last vowel-group boundary).
- */
 const AGGLUTINATIVE_FAMILIES = new Set(['ALGO-TRK', 'ALGO-FIN', 'ALGO-KOR']);
 
 /**
- * Detect whether a line contains an internal rhyme by scanning for a
- * repeated rhyme suffix pattern before the final word.
- *
- * Strategy: derive the last-vowel-group suffix for each candidate token and
- * for the end word, then check whether one suffix is a prefix of the other
- * (which handles trailing silent consonants, e.g. "nuit" suffix "uit" matches
- * "lui" suffix "ui" because "uit" starts with "ui"). The shared nucleus must
- * be at least 2 characters to avoid false positives on common single-vowel
- * endings like "e".
- *
- * Returns the mid-line token that mirrors the end rhyme, or null if none.
+ * Detect whether a line contains an internal rhyme.
+ * Uses last-vowel-group suffix of each token vs end word.
+ * Requires >= 2 shared characters to avoid false positives.
  */
-const detectInternalRhymeToken = (tokens: string[], lastWord: string, langCode?: string): string | null => {
+const detectInternalRhymeToken = (
+  tokens: string[],
+  lastWord: string,
+  langCode?: string,
+): string | null => {
   if (tokens.length < 2) return null;
-
-  // Derive last-vowel-group suffix for the end word.
   const lwVowelGroups = getVowelGroups(lastWord);
   const lwLastVG = lwVowelGroups.length > 0 ? lwVowelGroups[lwVowelGroups.length - 1]! : null;
-  const lwSuffix = lwLastVG !== null
-    ? canonicalizeRhymeSuffix(lastWord.slice(lwLastVG.start), langCode)
-    : canonicalizeRhymeSuffix(lastWord, langCode);
-
-  // A single-character nucleus is too common to be a meaningful internal rhyme.
+  const lwSuffix =
+    lwLastVG !== null
+      ? canonicalizeRhymeSuffix(lastWord.slice(lwLastVG.start), langCode)
+      : canonicalizeRhymeSuffix(lastWord, langCode);
   if (!lwSuffix || lwSuffix.length < 2) return null;
-
   const candidates = tokens.slice(0, -1);
   for (const token of candidates) {
     const normalized = normalizeWord(token, langCode);
     if (!normalized) continue;
-
     const vowelGroups = getVowelGroups(normalized);
     const lastVG = vowelGroups.length > 0 ? vowelGroups[vowelGroups.length - 1]! : null;
-    const suffix = lastVG !== null
-      ? canonicalizeRhymeSuffix(normalized.slice(lastVG.start), langCode)
-      : canonicalizeRhymeSuffix(normalized, langCode);
-
+    const suffix =
+      lastVG !== null
+        ? canonicalizeRhymeSuffix(normalized.slice(lastVG.start), langCode)
+        : canonicalizeRhymeSuffix(normalized, langCode);
     if (!suffix) continue;
-
-    // One suffix must be a leading prefix of the other so that "uit"/"ui"
-    // (nuit/lui) and "oir"/"oir" (soir/avoir) both match, while "e"/"are"
-    // (marche/encore) do not. Require >= 2 shared characters.
     const shared = suffix.startsWith(lwSuffix)
       ? lwSuffix
       : lwSuffix.startsWith(suffix)
         ? suffix
         : null;
-
     if (shared && shared.length >= 2) return token;
   }
   return null;
 };
 
 /**
- * Step-0 of the rhyme pipeline: segment a raw verse line into its rhyming
- * unit before passing to G2P / IPA scoring.
+ * Step-0: segment a raw verse line into its rhyming unit.
  *
- * Rules applied in order:
- * 1. Strip trailing punctuation; tokenize on whitespace.
- * 2. For agglutinative families (TRK/FIN/KOR): take the last word, extract
- *    its last stressed syllable (last vowel-group), use that as rhymingUnit.
- * 3. Enjambement heuristic: if the last normalized token is a known connector
- *    word, mark position as 'enjambed' and use the penultimate content word.
- * 4. Internal rhyme detection: check whether any pre-final token shares the
- *    end-rhyme suffix. If found, mark position as 'internal'.
- * 5. Default: last word of line → position 'end'.
+ * Rules (in order):
+ * 1. Agglutinative families (TRK/FIN/KOR): last stressed syllable of last word.
+ * 2. Enjambement: last token is a known connector → use penultimate content word.
+ * 3. Internal rhyme: pre-final token mirrors end-word suffix → mark 'internal'.
+ * 4. Default: last word → position 'end'.
  *
- * Tonal languages (KWA/CRV/BNT/SIN/TAI/VIET): extractLastWord is called
- * without diacritic stripping so tone marks are preserved in rhymingUnit.
- *
- * @param line       Raw verse line text
- * @param langCode   ISO 639 code; undefined → ALGO-ROM rules
- * @returns          VerseRhymingSegment ready for pipeline step 1
+ * Tonal languages: diacritic stripping is suppressed so tone marks survive.
  */
-export const segmentVerseToRhymingUnit = (line: string, langCode?: string): VerseRhymingSegment => {
+export const segmentVerseToRhymingUnit = (
+  line: string,
+  langCode?: string,
+): VerseRhymingSegment => {
   const family = langCode ? getAlgoFamily(langCode) : undefined;
-
-  // Tokenize: strip trailing punctuation then split on whitespace
   const stripped = line.trimEnd().replace(/[^\p{L}\p{N}\s]+$/u, '').trim();
   const tokens = stripped.split(/\s+/).filter(Boolean);
-
   if (tokens.length === 0) {
     return { rhymingUnit: '', position: 'end', originalText: line };
   }
-
-  // ── Agglutinative: pick last stressed syllable of last word ──────────────
+  // ── Agglutinative: last stressed syllable ────────────────────────────────
   if (family && AGGLUTINATIVE_FAMILIES.has(family)) {
     const lastToken = tokens[tokens.length - 1]!;
     const normalized = normalizeWord(lastToken, langCode);
     const vowelGroups = getVowelGroups(normalized);
-    // For non-Latin scripts (e.g. Hangul) normalizeWord may strip everything;
-    // fall back to the original token so rhymingUnit is never empty.
-    const rhymingUnit = vowelGroups.length > 0
-      ? normalized.slice(vowelGroups[vowelGroups.length - 1]!.start)
-      : (normalized || lastToken);
-    return {
-      rhymingUnit,
-      position: 'end',
-      originalText: line,
-    };
+    const rhymingUnit =
+      vowelGroups.length > 0
+        ? normalized.slice(vowelGroups[vowelGroups.length - 1]!.start)
+        : normalized || lastToken;
+    return { rhymingUnit, position: 'end', originalText: line };
   }
-
-  // ── Enjambement heuristic ─────────────────────────────────────────────────
+  // ── Enjambement ──────────────────────────────────────────────────────────
   const lastToken = tokens[tokens.length - 1]!;
   const lastNormalized = normalizeWord(lastToken, langCode);
   if (ENJAMBMENT_CONNECTORS.has(lastNormalized) && tokens.length >= 2) {
     const contentToken = tokens[tokens.length - 2]!;
-    const contentNormalized = normalizeWord(contentToken, langCode);
     return {
-      rhymingUnit: contentNormalized,
+      rhymingUnit: normalizeWord(contentToken, langCode),
       position: 'enjambed',
       originalText: line,
     };
   }
-
-  // ── Internal rhyme detection ──────────────────────────────────────────────
+  // ── Internal rhyme ───────────────────────────────────────────────────────
   const wordMatch = extractLastWord(stripped, langCode);
   if (wordMatch) {
     const internalToken = detectInternalRhymeToken(tokens, wordMatch.normalizedWord, langCode);
     if (internalToken) {
-      return {
-        rhymingUnit: wordMatch.normalizedWord,
-        position: 'internal',
-        originalText: line,
-      };
+      return { rhymingUnit: wordMatch.normalizedWord, position: 'internal', originalText: line };
+    }
+  }
+  // ── Default: end rhyme ───────────────────────────────────────────────────
+  const rhymingUnit = wordMatch ? wordMatch.normalizedWord : lastNormalized;
+  return { rhymingUnit, position: 'end', originalText: line };
+};
+
+/**
+ * Split a line at the start of a rhyming suffix, using Step-0 segmentation
+ * to resolve agglutinative, enjambed and internal cases first.
+ *
+ * When peerLines are supplied the best shared suffix across all peers is
+ * used; otherwise falls back to the last vowel group of the rhymingUnit.
+ */
+export const splitRhymingSuffix = (
+  text: string,
+  peerLines: string[] = [],
+  langCode?: string,
+): { before: string; rhyme: string } | null => {
+  // Step-0: resolve rhyming unit for the target line
+  const segment = segmentVerseToRhymingUnit(text, langCode);
+  // For enjambed lines the rhymingUnit is the penultimate word — we still
+  // split the *original* text at the suffix position of that word.
+  const effectiveText =
+    segment.position === 'enjambed'
+      ? text // splitLineAtNormalizedSuffix will locate the word inside text
+      : text;
+
+  let bestSuffix: string | null = null;
+  for (const peerLine of peerLines) {
+    // Step-0 on each peer as well so we compare rhymingUnits, not raw lines
+    const peerSegment = segmentVerseToRhymingUnit(peerLine, langCode);
+    const sharedSuffix = findBestSharedRhymeSuffix(
+      segment.rhymingUnit,
+      peerSegment.rhymingUnit,
+      langCode,
+    );
+    if (sharedSuffix && (!bestSuffix || sharedSuffix.length > bestSuffix.length)) {
+      bestSuffix = sharedSuffix;
     }
   }
 
-  // ── Default: end rhyme ────────────────────────────────────────────────────
-  const rhymingUnit = wordMatch ? wordMatch.normalizedWord : lastNormalized;
-  return {
-    rhymingUnit,
-    position: 'end',
-    originalText: line,
-  };
+  if (bestSuffix) {
+    const split = splitLineAtNormalizedSuffix(effectiveText, bestSuffix, langCode);
+    if (split) return split;
+  }
+
+  return getFallbackRhymingSuffix(effectiveText, langCode);
 };
 
-// ─── Existing exports unchanged below ────────────────────────────────────────
+/**
+ * Two lines rhyme when they share a strong enough rime suffix.
+ * Uses Step-0 segmentation so agglutinative/tonal/enjambed lines are
+ * correctly normalised before comparison.
+ */
+export const doLinesRhymeGraphemic = (a: string, b: string, langCode?: string): boolean => {
+  const segA = segmentVerseToRhymingUnit(a, langCode);
+  const segB = segmentVerseToRhymingUnit(b, langCode);
+  return findBestSharedRhymeSuffix(segA.rhymingUnit, segB.rhymingUnit, langCode) !== null;
+};
+
+// ─── Similarity / song-level utilities ───────────────────────────────────────
 
 const tokenize = (text: string) =>
   normalizeText(text)
@@ -518,27 +427,18 @@ const getSetOverlapRatio = (left: string[], right: string[]) => {
   return ratio(intersection, union);
 };
 
-const getSharedKeywords = (
-  currentTokens: string[],
-  candidateSong: Section[],
-) => {
+const getSharedKeywords = (currentTokens: string[], candidateSong: Section[]) => {
   const currentCounts = new Map<string, number>();
   const candidateCounts = new Map<string, number>();
-
   for (const token of currentTokens) {
     currentCounts.set(token, (currentCounts.get(token) || 0) + 1);
   }
-
   for (const token of getSongTokens(candidateSong)) {
     candidateCounts.set(token, (candidateCounts.get(token) || 0) + 1);
   }
-
   return [...currentCounts.entries()]
     .filter(([token]) => candidateCounts.has(token))
-    .map(([token, count]) => ({
-      token,
-      weight: count + (candidateCounts.get(token) || 0),
-    }))
+    .map(([token, count]) => ({ token, weight: count + (candidateCounts.get(token) || 0) }))
     .sort((a, b) => b.weight - a.weight || a.token.localeCompare(b.token))
     .slice(0, 5)
     .map(item => item.token);
@@ -548,25 +448,18 @@ const getMatchedSections = (currentSong: Section[], candidateSong: Section[]) =>
   const candidateByName = new Map(
     candidateSong.map(section => [normalizeText(section.name), section] as const),
   );
-
   return currentSong
-    .map((section) => {
+    .map(section => {
       const candidateSection = candidateByName.get(normalizeText(section.name));
       if (!candidateSection) return null;
-
       const sectionScore = Math.round(
         getSetOverlapRatio(
           (section.lines ?? []).map(line => normalizeText(line.text ?? '')).filter(Boolean),
           (candidateSection.lines ?? []).map(line => normalizeText(line.text ?? '')).filter(Boolean),
         ) * 100,
       );
-
       if (sectionScore === 0) return null;
-
-      return {
-        name: section.name,
-        score: sectionScore,
-      };
+      return { name: section.name, score: sectionScore };
     })
     .filter((section): section is SimilaritySectionMatch => section !== null)
     .sort((a, b) => b.score - a.score || a.name.localeCompare(b.name));
@@ -582,18 +475,12 @@ const calculateSimilarity = (
   const candidateTokens = getSongTokens(candidateSong);
   const currentSections = currentSong.map(section => normalizeText(section.name));
   const candidateSections = candidateSong.map(section => normalizeText(section.name));
-
   const lineScore = getSetOverlapRatio(currentLines, candidateLines);
   const tokenScore = getSetOverlapRatio(currentTokens, candidateTokens);
   const structureScore = getSetOverlapRatio(currentSections, candidateSections);
-
   return Math.round((tokenScore * 0.6 + lineScore * 0.3 + structureScore * 0.1) * 100);
 };
 
-/**
- * Section-level lyric similarity and rhyme metadata live here.
- * For IPA phoneme distance/scoring, use ipaUtils.ts through ipaPipeline.ts.
- */
 export const calculateSimilarityWithMetadata = (
   currentSong: Section[],
   candidateSong: Section[],
@@ -604,10 +491,8 @@ export const calculateSimilarityWithMetadata = (
   const candidateTokenSet = new Set(candidateTokens);
   const candidateLines = getSongLines(candidateSong);
   const candidateLineSet = new Set(candidateLines);
-
   const sharedWords = new Set(currentTokens.filter(token => candidateTokenSet.has(token))).size;
   const sharedLines = new Set(currentLines.filter(line => candidateLineSet.has(line))).size;
-
   return {
     score: calculateSimilarity(currentLines, currentTokens, candidateSong, currentSong),
     sharedWords,
@@ -624,21 +509,21 @@ export const getTopSimilarSongMatches = (
   limit = 3,
 ): SimilarityMatch[] => {
   if (currentSong.length === 0) return [];
-
   const currentTokens = getSongTokens(currentSong);
   const currentLines = getSongLines(currentSong);
-
   return versions
     .filter(version => (version.song ?? []).length > 0)
-    .map((version) => {
+    .map(version => {
       const candidateTokens = getSongTokens(version.song);
       const candidateTokenSet = new Set(candidateTokens);
       const candidateLines = getSongLines(version.song);
       const candidateLineSet = new Set(candidateLines);
-
-      const sharedWords = new Set(currentTokens.filter(token => candidateTokenSet.has(token))).size;
-      const sharedLines = new Set(currentLines.filter(line => candidateLineSet.has(line))).size;
-
+      const sharedWords = new Set(
+        currentTokens.filter(token => candidateTokenSet.has(token)),
+      ).size;
+      const sharedLines = new Set(
+        currentLines.filter(line => candidateLineSet.has(line)),
+      ).size;
       return {
         versionId: version.id,
         versionName: version.name,

--- a/src/utils/rhymeDetection.ts
+++ b/src/utils/rhymeDetection.ts
@@ -15,33 +15,17 @@ type RhymeCandidate = {
   normalizedSuffix: string;
 };
 
-/**
- * Full IPA vowel inventory covering Latin, Germanic umlauts, Slavic, Uralic,
- * Austronesian, Dravidian and Sinitic vowel characters encountered after NFD
- * normalization. Extending beyond 'aeiouy' fixes getVowelGroups for
- * ALGO-GER, ALGO-FIN, ALGO-DRV, ALGO-AUS, ALGO-SLV, ALGO-SIN, ALGO-KOR.
- */
 const VOWELS = new Set([
-  // Basic Latin
   'a', 'e', 'i', 'o', 'u', 'y',
-  // IPA close / mid vowels
-  'ɑ', 'ɒ', 'ɔ', 'ɛ', 'œ', 'ø', 'ɪ', 'ʊ', 'ʌ', 'ə', 'ɨ', 'ɵ', 'ɜ', 'ɞ', 'ɐ', 'ʉ', 'ɯ', 'ɤ',
-  // Germanic / Uralic umlauts (post-NFD base chars)
-  'ä', 'ö', 'ü', 'å',
-  // Scandinavian / Uralic
-  'æ', 'ø',
-  // Slavic / IIR
-  'ы', 'э', 'я', 'ю', 'е', 'ё', 'и',
-  // Dravidian vowel letters (Tamil, Kannada, Malayalam — post-transliteration)
-  'ā', 'ī', 'ū', 'ṛ', 'ḷ', 'ē', 'ō', 'ai', 'au',
+  '\u0251', '\u0252', '\u0254', '\u025b', '\u0153', '\u00f8', '\u026a', '\u028a', '\u028c', '\u0259', '\u0268', '\u0275', '\u025c', '\u025e', '\u0250', '\u0289', '\u026f', '\u0264',
+  '\u00e4', '\u00f6', '\u00fc', '\u00e5',
+  '\u00e6', '\u00f8',
+  '\u044b', '\u044d', '\u044f', '\u044e', '\u0435', '\u0451', '\u0438',
+  '\u0101', '\u012b', '\u016b', '\u1e5b', '\u1e37', '\u0113', '\u014d', 'ai', 'au',
 ]);
 
 const isVowel = (ch: string) => VOWELS.has(ch);
 
-/**
- * Strip Unicode accents and lowercase — with optional tonal preservation.
- * For tonal languages (KWA, CRV families), tone diacritics are preserved.
- */
 const normalizeWord = (s: string, langCode?: string): string => {
   const normalized = s.normalize('NFD');
   const stripDiacritics = isTonalLanguage(langCode || '')
@@ -50,9 +34,6 @@ const normalizeWord = (s: string, langCode?: string): string => {
   return stripDiacritics.toLowerCase().replace(/[^a-z\u0300-\u036f]/g, '');
 };
 
-/**
- * Extract the final word-like token from a lyric line.
- */
 const extractLastWord = (text: string, langCode?: string): WordMatch | null => {
   const trimmedText = text.trimEnd().replace(/[^\p{L}\p{N}]+$/u, '');
   if (!trimmedText) return null;
@@ -64,9 +45,6 @@ const extractLastWord = (text: string, langCode?: string): WordMatch | null => {
   return { lastWord, normalizedWord, wordStart: lastWordMatch.index };
 };
 
-/**
- * Identify contiguous vowel groups inside a normalized word.
- */
 const getVowelGroups = (normalizedWord: string): VowelSpan[] => {
   const vowelGroups: VowelSpan[] = [];
   const chars = [...normalizedWord];
@@ -83,12 +61,6 @@ const getVowelGroups = (normalizedWord: string): VowelSpan[] => {
   return vowelGroups;
 };
 
-/**
- * Canonicalize rhyme suffix.
- * Romance-specific orthographic rules are gated on ALGO-ROM.
- * All other families return the raw suffix for IPA pipeline handling.
- * When langCode is absent the Romance rules apply as a safe default.
- */
 const canonicalizeRhymeSuffix = (suffix: string, langCode?: string): string => {
   const s = suffix.length <= 3 ? suffix : suffix.replace(/[sx]$/, '');
   const family = langCode ? getAlgoFamily(langCode) : undefined;
@@ -199,7 +171,7 @@ const getFallbackRhymingSuffix = (
   );
 };
 
-// ─── Step-0: verse segmentation ──────────────────────────────────────────────
+// ─── Step-0: verse segmentation ───────────────────────────────────────────────
 
 export type RhymePosition = 'end' | 'internal' | 'enjambed';
 
@@ -210,17 +182,6 @@ export type VerseRhymingSegment = {
   syllableIndex?: number;
 };
 
-/**
- * Connector words that suggest a line is syntactically incomplete
- * (enjambement). Checked against the normalized last token.
- *
- * Covers:
- * - Romance/Germanic (FR, EN, ES, IT, PT, DE, NL)
- * - KWA (Baoulé, Dioula, Ewe, Mina)
- * - BNT (Yoruba, Swahili, Zulu, Lingala)
- * - CRV (Bekwarra, Ijaw)
- * - CRE / Pidgin (Nouchi, Nigerian Pidgin)
- */
 const ENJAMBMENT_CONNECTORS = new Set([
   // French
   'et', 'ou', 'mais', 'donc', 'or', 'ni', 'car', 'que', 'qui', 'dont',
@@ -234,13 +195,13 @@ const ENJAMBMENT_CONNECTORS = new Set([
   // German / Dutch
   'und', 'oder', 'aber', 'weil', 'mit', 'ohne', 'von', 'en', 'maar', 'van',
   // Yoruba (ALGO-BNT)
-  'ati', 'àti', 'tabi', 'tàbí', 'nitori', 'bi', 'ti', 'ni', 'si', 'fun',
+  'ati', '\u00e0ti', 'tabi', 't\u00e0b\u00ed', 'nitori', 'bi', 'ti', 'ni', 'si', 'fun',
   // Swahili (ALGO-BNT)
   'na', 'ya', 'wa', 'za', 'la', 'kwa', 'bila', 'hadi', 'au',
   // Dioula / Bambara (ALGO-KWA)
-  'ni', 'ka', 'ani', 'walima', 'nka', 'fo', 'kɔ',
-  // Baoulé (ALGO-KWA)
-  'mɔ', 'kɛ', 'yɛ',
+  'ni', 'ka', 'ani', 'walima', 'nka', 'fo', 'k\u0254',
+  // Baoul\u00e9 (ALGO-KWA)
+  'm\u0254', 'k\u025b', 'y\u025b',
   // Ewe / Mina (ALGO-KWA)
   'kple', 'eye', 'ke', 'ne', 'le',
   // Lingala (ALGO-BNT)
@@ -253,11 +214,6 @@ const ENJAMBMENT_CONNECTORS = new Set([
 
 const AGGLUTINATIVE_FAMILIES = new Set(['ALGO-TRK', 'ALGO-FIN', 'ALGO-KOR']);
 
-/**
- * Detect whether a line contains an internal rhyme.
- * Uses last-vowel-group suffix of each token vs end word.
- * Requires >= 2 shared characters to avoid false positives.
- */
 const detectInternalRhymeToken = (
   tokens: string[],
   lastWord: string,
@@ -292,17 +248,6 @@ const detectInternalRhymeToken = (
   return null;
 };
 
-/**
- * Step-0: segment a raw verse line into its rhyming unit.
- *
- * Rules (in order):
- * 1. Agglutinative families (TRK/FIN/KOR): last stressed syllable of last word.
- * 2. Enjambement: last token is a known connector → use penultimate content word.
- * 3. Internal rhyme: pre-final token mirrors end-word suffix → mark 'internal'.
- * 4. Default: last word → position 'end'.
- *
- * Tonal languages: diacritic stripping is suppressed so tone marks survive.
- */
 export const segmentVerseToRhymingUnit = (
   line: string,
   langCode?: string,
@@ -313,7 +258,7 @@ export const segmentVerseToRhymingUnit = (
   if (tokens.length === 0) {
     return { rhymingUnit: '', position: 'end', originalText: line };
   }
-  // ── Agglutinative: last stressed syllable ────────────────────────────────
+  // Agglutinative: last stressed syllable
   if (family && AGGLUTINATIVE_FAMILIES.has(family)) {
     const lastToken = tokens[tokens.length - 1]!;
     const normalized = normalizeWord(lastToken, langCode);
@@ -324,7 +269,7 @@ export const segmentVerseToRhymingUnit = (
         : normalized || lastToken;
     return { rhymingUnit, position: 'end', originalText: line };
   }
-  // ── Enjambement ──────────────────────────────────────────────────────────
+  // Enjambement
   const lastToken = tokens[tokens.length - 1]!;
   const lastNormalized = normalizeWord(lastToken, langCode);
   if (ENJAMBMENT_CONNECTORS.has(lastNormalized) && tokens.length >= 2) {
@@ -335,7 +280,7 @@ export const segmentVerseToRhymingUnit = (
       originalText: line,
     };
   }
-  // ── Internal rhyme ───────────────────────────────────────────────────────
+  // Internal rhyme
   const wordMatch = extractLastWord(stripped, langCode);
   if (wordMatch) {
     const internalToken = detectInternalRhymeToken(tokens, wordMatch.normalizedWord, langCode);
@@ -343,35 +288,34 @@ export const segmentVerseToRhymingUnit = (
       return { rhymingUnit: wordMatch.normalizedWord, position: 'internal', originalText: line };
     }
   }
-  // ── Default: end rhyme ───────────────────────────────────────────────────
+  // Default: end rhyme
   const rhymingUnit = wordMatch ? wordMatch.normalizedWord : lastNormalized;
   return { rhymingUnit, position: 'end', originalText: line };
 };
 
 /**
- * Split a line at the start of a rhyming suffix, using Step-0 segmentation
- * to resolve agglutinative, enjambed and internal cases first.
+ * Split a line at the start of a rhyming suffix.
  *
- * When peerLines are supplied the best shared suffix across all peers is
- * used; otherwise falls back to the last vowel group of the rhymingUnit.
+ * FIX (enjambed): when Step-0 detects an enjambed line, the trailing connector
+ * token is stripped from `text` before calling splitLineAtNormalizedSuffix so
+ * the highlight targets the content word, not the connector.
  */
 export const splitRhymingSuffix = (
   text: string,
   peerLines: string[] = [],
   langCode?: string,
 ): { before: string; rhyme: string } | null => {
-  // Step-0: resolve rhyming unit for the target line
   const segment = segmentVerseToRhymingUnit(text, langCode);
-  // For enjambed lines the rhymingUnit is the penultimate word — we still
-  // split the *original* text at the suffix position of that word.
+
+  // FIX: for enjambed lines, strip the trailing connector so the split
+  // operates on the text up to (and including) the content word.
   const effectiveText =
     segment.position === 'enjambed'
-      ? text // splitLineAtNormalizedSuffix will locate the word inside text
+      ? text.trimEnd().replace(/\s+\S+$/, '') // strip last token (the connector)
       : text;
 
   let bestSuffix: string | null = null;
   for (const peerLine of peerLines) {
-    // Step-0 on each peer as well so we compare rhymingUnits, not raw lines
     const peerSegment = segmentVerseToRhymingUnit(peerLine, langCode);
     const sharedSuffix = findBestSharedRhymeSuffix(
       segment.rhymingUnit,
@@ -391,18 +335,13 @@ export const splitRhymingSuffix = (
   return getFallbackRhymingSuffix(effectiveText, langCode);
 };
 
-/**
- * Two lines rhyme when they share a strong enough rime suffix.
- * Uses Step-0 segmentation so agglutinative/tonal/enjambed lines are
- * correctly normalised before comparison.
- */
 export const doLinesRhymeGraphemic = (a: string, b: string, langCode?: string): boolean => {
   const segA = segmentVerseToRhymingUnit(a, langCode);
   const segB = segmentVerseToRhymingUnit(b, langCode);
   return findBestSharedRhymeSuffix(segA.rhymingUnit, segB.rhymingUnit, langCode) !== null;
 };
 
-// ─── Similarity / song-level utilities ───────────────────────────────────────
+// ─── Similarity / song-level utilities ────────────────────────────────────────
 
 const tokenize = (text: string) =>
   normalizeText(text)

--- a/src/utils/songRhymeAnalysis.ts
+++ b/src/utils/songRhymeAnalysis.ts
@@ -1,285 +1,186 @@
-import { languageNameToCode } from '../constants/langFamilyMap';
+/**
+ * songRhymeAnalysis.ts
+ *
+ * Song-level rhyme analysis: groups lines by rhyme family, computes overlay
+ * split points, and detects rhyme scheme per section.
+ *
+ * langCode is threaded through all public functions so family-specific
+ * graphemic rules (tonal preservation, agglutinative syllable selection,
+ * extended enjambment connectors) are applied consistently.
+ */
+
+import { doLinesRhymeGraphemic, splitRhymingSuffix } from './rhymeDetection';
 import type { Section } from '../types';
-import { compareTextsWithIPA } from './ipaPipeline';
-import { detectRhymeSchemeFromIPAPairs, detectRhymeSchemeLocally } from './rhymeSchemeUtils';
-import { segmentVerseToRhymingUnit } from './rhymeDetection';
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+export interface RhymeGroup {
+  /** Canonical suffix shared by all lines in the group (canonicalized). */
+  suffix: string;
+  /** 0-based indices into the section's lines array. */
+  lineIndices: number[];
+}
+
+export interface RhymeOverlaySegment {
+  /** Text before the rhyming portion (before + whitespace from original). */
+  before: string;
+  /** The rhyming tail of the line as it should be highlighted in the UI. */
+  rhyme: string;
+  /** Structural position detected by Step-0 segmentation. */
+  position: 'end' | 'internal' | 'enjambed';
+}
+
+export interface SectionRhymeAnalysis {
+  /** Rhyme groups found in this section. */
+  groups: RhymeGroup[];
+  /** Per-line overlay data (parallel array to section.lines). */
+  overlays: (RhymeOverlaySegment | null)[];
+  /** Detected rhyme scheme string (e.g. "ABAB"), null when undetermined. */
+  scheme: string | null;
+}
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
 
 /**
- * Local rhyme comparison for a pair of lyric lines.
- * `quality` mirrors the IPA rhyme classifier, `confidenceScore` is the normalized
- * 0–100 score used by the hook, and `isApproximated` flags mocked or downgraded
- * near-matches that should count below an exact pair of the same base similarity.
- * `crossSection` is true when the two lines come from different sections.
- * `rhymePosition` reflects the structural role detected by segmentVerseToRhymingUnit
- * ('end' | 'internal' | 'enjambed') so the UI can highlight accordingly.
- * `crossFamily` is true when the two lines were analyzed through different
- * language pipelines (code-switching pair).
- */
-export type LocalRhymePairAnalysis = {
-  lineIndexes: [number, number];
-  lines: [string, string];
-  quality: string;
-  confidenceScore: number;
-  usedIpa: boolean;
-  isApproximated: boolean;
-  crossSection?: boolean;
-  rhymePosition?: 'end' | 'internal' | 'enjambed';
-  crossFamily?: boolean;
-};
-
-/**
- * Per-section rhyme diagnostics built locally before any AI analysis.
- * `mode: "ipa"` means a supported language was analyzed through compareTextsWithIPA,
- * while `mode: "graphemic"` indicates an unsupported language or graceful fallback.
- * `isProxied` is true when the G2P family is handled by a proxy stub.
- */
-export type LocalRhymeSectionAnalysis = {
-  sectionId: string;
-  sectionName: string;
-  langCode?: string;
-  detectedScheme: string | null;
-  mode: 'ipa' | 'graphemic';
-  isProxied: boolean;
-  pairs: LocalRhymePairAnalysis[];
-};
-
-/** Families with a native G2P implementation (non-proxy). */
-const NATIVE_G2P_FAMILIES = new Set(['ALGO-ROM', 'ALGO-GER', 'ALGO-KWA', 'ALGO-CRV', 'ALGO-SEM']);
-
-const toPairConfidenceScore = (similarity: { score?: number; isApproximated?: boolean }) => {
-  const baseScore = typeof similarity.score === 'number' ? similarity.score : 0;
-  const adjustedScore = similarity.isApproximated ? baseScore * 0.85 : baseScore;
-  return Math.round(adjustedScore * 1000) / 10;
-};
-
-/**
- * Detect the language of a single line when it may differ from the section
- * language (code-switching). Returns the section langCode as default when
- * no override is detected.
+ * Build rhyme groups for a flat list of line texts.
  *
- * Strategy (lightweight, no external call):
- * - If the line contains a per-line language annotation in the form
- *   «[lang:xx]» at the start, use that code (stripped before analysis).
- * - Otherwise return the section langCode unchanged.
+ * Strategy: for each unassigned line, find all later lines that rhyme with it
+ * (via doLinesRhymeGraphemic, which now applies Step-0 segmentation). Lines
+ * that share a rhyme are placed in the same group.
  *
- * This intentionally avoids a full LID call per-line to keep the pipeline
- * synchronous-friendly. A future upgrade can inject a real LID result here.
- *
- * @param lineText    Raw line text (may contain inline lang tag)
- * @param sectionLang Section-level ISO 639 code
- * @returns           { text: cleaned text, langCode: resolved code }
+ * @param lines    Raw line texts
+ * @param langCode ISO 639 code — propagated to all graphemic comparisons
  */
-const detectLineLang = (
-  lineText: string,
-  sectionLang: string,
-): { text: string; langCode: string } => {
-  const INLINE_TAG = /^\[lang:([a-z]{2,3}(?:-[a-z]{2})?)\]\s*/i;
-  const match = INLINE_TAG.exec(lineText);
-  if (match) {
-    return {
-      text: lineText.slice(match[0].length),
-      langCode: match[1]!.toLowerCase(),
-    };
+export const buildRhymeGroups = (lines: string[], langCode?: string): RhymeGroup[] => {
+  const n = lines.length;
+  const groupIndex = new Array<number | null>(n).fill(null);
+  const groups: RhymeGroup[] = [];
+
+  for (let i = 0; i < n; i++) {
+    if (groupIndex[i] !== null) continue;
+    if (!lines[i]?.trim()) continue;
+
+    const members: number[] = [i];
+    for (let j = i + 1; j < n; j++) {
+      if (!lines[j]?.trim()) continue;
+      if (doLinesRhymeGraphemic(lines[i]!, lines[j]!, langCode)) {
+        members.push(j);
+      }
+    }
+
+    if (members.length < 2) continue; // singleton — not a rhyme group
+
+    const gIdx = groups.length;
+    for (const idx of members) groupIndex[idx] = gIdx;
+
+    // Derive a representative suffix for the group: use the split from the
+    // first line against the second rhyming peer.
+    const split = splitRhymingSuffix(lines[i]!, [lines[members[1]]!], langCode);
+    groups.push({
+      suffix: split?.rhyme ?? '',
+      lineIndices: members,
+    });
   }
-  return { text: lineText, langCode: sectionLang };
+
+  return groups;
 };
 
 /**
- * Builds lightweight, local rhyme diagnostics for each song section.
+ * Compute overlay segments for every line in a section.
  *
- * Changes vs. previous version:
- * - Each line is passed through segmentVerseToRhymingUnit() (step-0) before
- *   IPA comparison so the pipeline receives the correct rhyming unit rather
- *   than the raw full line.
- * - rhymePosition from segmentation is forwarded to LocalRhymePairAnalysis.
- * - Per-line language override via detectLineLang() enables cross-family
- *   code-switching pairs. When line A and line B resolve to different langCodes,
- *   its own G2P family, and this stage records the resulting similarity-based
- *   diagnostics without applying any thresholding.
+ * Each line receives a split point derived from its rhyme peers inside the
+ * same section. Lines with no rhyme peer receive null.
  *
- * @param song - The song sections to analyze
- * @param detectCrossSectionBoundary - When true, also compares the last line of
- *   each section against the first line of the next (rime bridges).
+ * @param lines    Raw line texts
+ * @param groups   Pre-computed RhymeGroup[] for this section
+ * @param langCode ISO 639 code — propagated to splitRhymingSuffix
  */
-export const analyzeSongRhymes = async (
-  song: Section[],
-  detectCrossSectionBoundary = false,
-): Promise<LocalRhymeSectionAnalysis[]> => {
-  const results = await Promise.all(song.map(async (section, sectionIndex) => {
-    const rawLyricLines = section.lines
-      .filter(line => !line.isMeta)
-      .map(line => line.text.trim())
+export const buildRhymeOverlays = (
+  lines: string[],
+  groups: RhymeGroup[],
+  langCode?: string,
+): (RhymeOverlaySegment | null)[] => {
+  // Build a reverse map: lineIndex → group
+  const lineToGroup = new Map<number, RhymeGroup>();
+  for (const group of groups) {
+    for (const idx of group.lineIndices) lineToGroup.set(idx, group);
+  }
+
+  return lines.map((line, i) => {
+    const group = lineToGroup.get(i);
+    if (!group) return null;
+
+    // Peer lines = all other members of the same group
+    const peerLines = group.lineIndices
+      .filter(idx => idx !== i)
+      .map(idx => lines[idx]!)
       .filter(Boolean);
 
-    const sectionLangCode = languageNameToCode(section.language ?? '');
+    const split = splitRhymingSuffix(line, peerLines, langCode);
+    if (!split) return null;
 
-    const { getAlgoFamily } = await import('../constants/langFamilyMap');
-    const family = sectionLangCode ? getAlgoFamily(sectionLangCode) : undefined;
-    const isProxied = family ? !NATIVE_G2P_FAMILIES.has(family) : false;
+    // Resolve position from segmentation metadata
+    // (doLinesRhymeGraphemic already ran segmentation; we derive position
+    // from the split result — if rhyme === whole line it's likely enjambed)
+    const position: RhymeOverlaySegment['position'] =
+      split.before.trim() === '' ? 'enjambed' : 'end';
 
-    // Step-0 segmentation: resolve rhyming unit + position for each line.
-    // Also apply per-line language detection for code-switching.
-    const segmented = rawLyricLines.map(rawLine => {
-      const resolved = sectionLangCode
-        ? detectLineLang(rawLine, sectionLangCode)
-        : { text: rawLine, langCode: sectionLangCode ?? '' };
-      const segment = segmentVerseToRhymingUnit(resolved.text, resolved.langCode || undefined);
-      return {
-        rawText: resolved.text,
-        langCode: resolved.langCode,
-        rhymingUnit: segment.rhymingUnit,
-        position: segment.position,
-      };
-    });
+    return { before: split.before, rhyme: split.rhyme, position };
+  });
+};
 
-    // Use raw texts for graphemic fallback (scheme detection operates on full lines)
-    const lyricLines = segmented.map(s => s.rawText);
+/**
+ * Derive a letter-based rhyme scheme string from groups and line count.
+ * Returns null when fewer than 2 rhyming groups are present.
+ *
+ * @param lineCount Total lines in the section
+ * @param groups    RhymeGroup[] for the section
+ */
+export const buildRhymeScheme = (lineCount: number, groups: RhymeGroup[]): string | null => {
+  if (groups.length < 1) return null;
 
-    const graphemicScheme = detectRhymeSchemeLocally(lyricLines, sectionLangCode);
+  const letters = new Array<string>(lineCount).fill('');
+  const alphabet = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ';
+  let nextLetter = 0;
 
-    if (!sectionLangCode || lyricLines.length < 2) {
-      return {
-        sectionId: section.id,
-        sectionName: section.name,
-        ...(sectionLangCode !== undefined ? { langCode: sectionLangCode } : {}),
-        detectedScheme: graphemicScheme,
-        mode: 'graphemic' as const,
-        isProxied,
-        pairs: [] as LocalRhymePairAnalysis[],
-        _sectionIndex: sectionIndex,
-        _lyricLines: lyricLines,
-        _segmented: segmented,
-      };
-    }
-
-    try {
-      const pairs: LocalRhymePairAnalysis[] = [];
-
-      for (let firstIndex = 0; firstIndex < segmented.length; firstIndex++) {
-        for (let secondIndex = firstIndex + 1; secondIndex < segmented.length; secondIndex++) {
-          const first = segmented[firstIndex]!;
-          const second = segmented[secondIndex]!;
-
-          // Determine if this is a cross-family (code-switching) pair
-          const isCrossFamily = first.langCode !== second.langCode;
-
-          // Use rhymingUnit for IPA input; fall back to rawText if empty
-          const inputA = first.rhymingUnit || first.rawText;
-          const inputB = second.rhymingUnit || second.rawText;
-
-          const similarity = await compareTextsWithIPA(
-            inputA,
-            inputB,
-            first.langCode,
-            isCrossFamily ? { langCode2: second.langCode } : undefined,
-          );
-
-          // Position is that of the first line (dominant structural signal)
-          const rhymePosition = first.position;
-
-          pairs.push({
-            lineIndexes: [firstIndex, secondIndex],
-            lines: [first.rawText, second.rawText],
-            quality: similarity.quality,
-            confidenceScore: toPairConfidenceScore(similarity as { score?: number; isApproximated?: boolean }),
-            usedIpa: true,
-            isApproximated: Boolean((similarity as { isApproximated?: boolean }).isApproximated),
-            rhymePosition,
-            ...(isCrossFamily && { crossFamily: true }),
-          });
-        }
-      }
-
-      const ipaScheme = detectRhymeSchemeFromIPAPairs(lyricLines.length, pairs);
-
-      return {
-        sectionId: section.id,
-        sectionName: section.name,
-        ...(sectionLangCode !== undefined ? { langCode: sectionLangCode } : {}),
-        detectedScheme: ipaScheme ?? graphemicScheme,
-        mode: 'ipa' as const,
-        isProxied,
-        pairs,
-        _sectionIndex: sectionIndex,
-        _lyricLines: lyricLines,
-        _segmented: segmented,
-      };
-    } catch {
-      return {
-        sectionId: section.id,
-        sectionName: section.name,
-        ...(sectionLangCode !== undefined ? { langCode: sectionLangCode } : {}),
-        detectedScheme: graphemicScheme,
-        mode: 'graphemic' as const,
-        isProxied,
-        pairs: [] as LocalRhymePairAnalysis[],
-        _sectionIndex: sectionIndex,
-        _lyricLines: lyricLines,
-        _segmented: segmented,
-      };
-    }
-  }));
-
-  // Cross-section boundary detection
-  if (detectCrossSectionBoundary && results.length >= 2) {
-    for (let i = 0; i < results.length - 1; i++) {
-      const current = results[i]!;
-      const next = results[i + 1]!;
-      const lastLine = current._lyricLines[current._lyricLines.length - 1];
-      const firstLine = next._lyricLines[0];
-
-      if (!lastLine || !firstLine) continue;
-
-      const langCode = current.langCode;
-
-      try {
-        if (langCode) {
-          const lastSeg = current._segmented[current._segmented.length - 1];
-          const firstSeg = next._segmented?.[0];
-          const isCrossFamily = lastSeg && firstSeg && lastSeg.langCode !== firstSeg.langCode;
-
-          const inputA = lastSeg?.rhymingUnit || lastLine;
-          const inputB = firstSeg?.rhymingUnit || firstLine;
-          const langA = lastSeg?.langCode || langCode;
-          const langB = firstSeg?.langCode || next.langCode || langCode;
-
-          const similarity = await compareTextsWithIPA(
-            inputA,
-            inputB,
-            langA,
-            isCrossFamily ? { langCode2: langB } : undefined,
-          );
-          current.pairs.push({
-            lineIndexes: [current._lyricLines.length - 1, -1],
-            lines: [lastLine, firstLine],
-            quality: similarity.quality,
-            confidenceScore: toPairConfidenceScore(similarity as { score?: number; isApproximated?: boolean }),
-            usedIpa: true,
-            isApproximated: Boolean((similarity as { isApproximated?: boolean }).isApproximated),
-            crossSection: true,
-            rhymePosition: lastSeg?.position ?? 'end',
-            ...(isCrossFamily && { crossFamily: true }),
-          });
-        } else {
-          const { doLinesRhymeGraphemic } = await import('./rhymeDetection');
-          if (doLinesRhymeGraphemic(lastLine, firstLine)) {
-            current.pairs.push({
-              lineIndexes: [current._lyricLines.length - 1, -1],
-              lines: [lastLine, firstLine],
-              quality: 'graphemic',
-              confidenceScore: 70,
-              usedIpa: false,
-              isApproximated: true,
-              crossSection: true,
-              rhymePosition: 'end',
-            });
-          }
-        }
-      } catch {
-        // Cross-section comparison is best-effort — never throw to caller.
-      }
+  for (const group of groups) {
+    const letter = alphabet[nextLetter % alphabet.length] ?? String.fromCharCode(65 + nextLetter);
+    nextLetter++;
+    for (const idx of group.lineIndices) {
+      if (idx < lineCount) letters[idx] = letter;
     }
   }
 
-  return results.map(({ _sectionIndex: _si, _lyricLines: _ll, _segmented: _sg, ...rest }) => rest);
+  const scheme = letters.join('');
+  // A scheme with fewer than 2 distinct non-empty letters is not meaningful
+  const distinctLetters = new Set(letters.filter(Boolean));
+  return distinctLetters.size >= 2 ? scheme : null;
 };
+
+/**
+ * Full analysis for a single section.
+ *
+ * @param section  Section object from the song data model
+ * @param langCode ISO 639 code for the song's primary language
+ */
+export const analyseSection = (
+  section: Section,
+  langCode?: string,
+): SectionRhymeAnalysis => {
+  const lines = (section.lines ?? []).map(l => l.text ?? '');
+  const groups = buildRhymeGroups(lines, langCode);
+  const overlays = buildRhymeOverlays(lines, groups, langCode);
+  const scheme = buildRhymeScheme(lines.length, groups);
+  return { groups, overlays, scheme };
+};
+
+/**
+ * Full analysis for an entire song (all sections).
+ *
+ * @param sections Song sections
+ * @param langCode ISO 639 code for the song's primary language
+ */
+export const analyseSong = (
+  sections: Section[],
+  langCode?: string,
+): SectionRhymeAnalysis[] => sections.map(section => analyseSection(section, langCode));

--- a/src/utils/songRhymeAnalysis.ts
+++ b/src/utils/songRhymeAnalysis.ts
@@ -1,55 +1,110 @@
-/**
- * songRhymeAnalysis.ts
- *
- * Song-level rhyme analysis: groups lines by rhyme family, computes overlay
- * split points, and detects rhyme scheme per section.
- *
- * langCode is threaded through all public functions so family-specific
- * graphemic rules (tonal preservation, agglutinative syllable selection,
- * extended enjambment connectors) are applied consistently.
- */
-
-import { doLinesRhymeGraphemic, splitRhymingSuffix } from './rhymeDetection';
+import { languageNameToCode } from '../constants/langFamilyMap';
 import type { Section } from '../types';
+import { compareTextsWithIPA } from './ipaPipeline';
+import { detectRhymeSchemeFromIPAPairs, detectRhymeSchemeLocally } from './rhymeSchemeUtils';
+import {
+  doLinesRhymeGraphemic,
+  segmentVerseToRhymingUnit,
+  splitRhymingSuffix,
+} from './rhymeDetection';
 
-// ─── Types ────────────────────────────────────────────────────────────────────
+/**
+ * Local rhyme comparison for a pair of lyric lines.
+ * `quality` mirrors the IPA rhyme classifier, `confidenceScore` is the normalized
+ * 0–100 score used by the hook, and `isApproximated` flags mocked or downgraded
+ * near-matches that should count below an exact pair of the same base similarity.
+ * `crossSection` is true when the two lines come from different sections.
+ * `rhymePosition` reflects the structural role detected by segmentVerseToRhymingUnit
+ * ('end' | 'internal' | 'enjambed') so the UI can highlight accordingly.
+ * `crossFamily` is true when the two lines were analyzed through different
+ * language pipelines (code-switching pair).
+ */
+export type LocalRhymePairAnalysis = {
+  lineIndexes: [number, number];
+  lines: [string, string];
+  quality: string;
+  confidenceScore: number;
+  usedIpa: boolean;
+  isApproximated: boolean;
+  crossSection?: boolean;
+  rhymePosition?: 'end' | 'internal' | 'enjambed';
+  crossFamily?: boolean;
+};
+
+/**
+ * Per-section rhyme diagnostics built locally before any AI analysis.
+ * `mode: "ipa"` means a supported language was analyzed through compareTextsWithIPA,
+ * while `mode: "graphemic"` indicates an unsupported language or graceful fallback.
+ * `isProxied` is true when the G2P family is handled by a proxy stub.
+ */
+export type LocalRhymeSectionAnalysis = {
+  sectionId: string;
+  sectionName: string;
+  langCode?: string;
+  detectedScheme: string | null;
+  mode: 'ipa' | 'graphemic';
+  isProxied: boolean;
+  pairs: LocalRhymePairAnalysis[];
+};
+
+// ─── New helpers (also exported for rhymeSchemeUtils / UI consumers) ──────────
 
 export interface RhymeGroup {
-  /** Canonical suffix shared by all lines in the group (canonicalized). */
+  /** Representative suffix shared by all lines in the group. */
   suffix: string;
-  /** 0-based indices into the section's lines array. */
+  /** 0-based indices into the lyric-only lines array passed to buildRhymeGroups. */
   lineIndices: number[];
 }
 
 export interface RhymeOverlaySegment {
-  /** Text before the rhyming portion (before + whitespace from original). */
   before: string;
-  /** The rhyming tail of the line as it should be highlighted in the UI. */
   rhyme: string;
-  /** Structural position detected by Step-0 segmentation. */
+  /** Structural position resolved by segmentVerseToRhymingUnit (Step-0). */
   position: 'end' | 'internal' | 'enjambed';
 }
 
 export interface SectionRhymeAnalysis {
-  /** Rhyme groups found in this section. */
   groups: RhymeGroup[];
-  /** Per-line overlay data (parallel array to section.lines). */
   overlays: (RhymeOverlaySegment | null)[];
-  /** Detected rhyme scheme string (e.g. "ABAB"), null when undetermined. */
   scheme: string | null;
 }
 
-// ─── Helpers ──────────────────────────────────────────────────────────────────
+// ─── Families with a native G2P implementation ───────────────────────────────
+
+const NATIVE_G2P_FAMILIES = new Set(['ALGO-ROM', 'ALGO-GER', 'ALGO-KWA', 'ALGO-CRV', 'ALGO-SEM']);
+
+const toPairConfidenceScore = (similarity: { score?: number; isApproximated?: boolean }) => {
+  const baseScore = typeof similarity.score === 'number' ? similarity.score : 0;
+  const adjustedScore = similarity.isApproximated ? baseScore * 0.85 : baseScore;
+  return Math.round(adjustedScore * 1000) / 10;
+};
 
 /**
- * Build rhyme groups for a flat list of line texts.
+ * Detect the language of a single line when it may differ from the section
+ * language (code-switching).
+ */
+const detectLineLang = (
+  lineText: string,
+  sectionLang: string,
+): { text: string; langCode: string } => {
+  const INLINE_TAG = /^\[lang:([a-z]{2,3}(?:-[a-z]{2})?)\]\s*/i;
+  const match = INLINE_TAG.exec(lineText);
+  if (match) {
+    return {
+      text: lineText.slice(match[0].length),
+      langCode: match[1]!.toLowerCase(),
+    };
+  }
+  return { text: lineText, langCode: sectionLang };
+};
+
+// ─── buildRhymeGroups ─────────────────────────────────────────────────────────
+
+/**
+ * Build rhyme groups for a flat list of lyric-only line texts.
  *
- * Strategy: for each unassigned line, find all later lines that rhyme with it
- * (via doLinesRhymeGraphemic, which now applies Step-0 segmentation). Lines
- * that share a rhyme are placed in the same group.
- *
- * @param lines    Raw line texts
- * @param langCode ISO 639 code — propagated to all graphemic comparisons
+ * FIX: inner loop now skips already-assigned lines (groupIndex[j] !== null)
+ * to prevent the same line from appearing in multiple groups.
  */
 export const buildRhymeGroups = (lines: string[], langCode?: string): RhymeGroup[] => {
   const n = lines.length;
@@ -62,19 +117,19 @@ export const buildRhymeGroups = (lines: string[], langCode?: string): RhymeGroup
 
     const members: number[] = [i];
     for (let j = i + 1; j < n; j++) {
+      // FIX: skip lines already claimed by an earlier group
+      if (groupIndex[j] !== null) continue;
       if (!lines[j]?.trim()) continue;
       if (doLinesRhymeGraphemic(lines[i]!, lines[j]!, langCode)) {
         members.push(j);
       }
     }
 
-    if (members.length < 2) continue; // singleton — not a rhyme group
+    if (members.length < 2) continue;
 
     const gIdx = groups.length;
     for (const idx of members) groupIndex[idx] = gIdx;
 
-    // Derive a representative suffix for the group: use the split from the
-    // first line against the second rhyming peer.
     const split = splitRhymingSuffix(lines[i]!, [lines[members[1]]!], langCode);
     groups.push({
       suffix: split?.rhyme ?? '',
@@ -85,22 +140,20 @@ export const buildRhymeGroups = (lines: string[], langCode?: string): RhymeGroup
   return groups;
 };
 
+// ─── buildRhymeOverlays ───────────────────────────────────────────────────────
+
 /**
- * Compute overlay segments for every line in a section.
+ * Compute overlay segments for every lyric line.
  *
- * Each line receives a split point derived from its rhyme peers inside the
- * same section. Lines with no rhyme peer receive null.
- *
- * @param lines    Raw line texts
- * @param groups   Pre-computed RhymeGroup[] for this section
- * @param langCode ISO 639 code — propagated to splitRhymingSuffix
+ * FIX: position is derived from segmentVerseToRhymingUnit() (Step-0) instead
+ * of being inferred from split.before.trim(), which was unreliable for enjambed
+ * and internal rhymes.
  */
 export const buildRhymeOverlays = (
   lines: string[],
   groups: RhymeGroup[],
   langCode?: string,
 ): (RhymeOverlaySegment | null)[] => {
-  // Build a reverse map: lineIndex → group
   const lineToGroup = new Map<number, RhymeGroup>();
   for (const group of groups) {
     for (const idx of group.lineIndices) lineToGroup.set(idx, group);
@@ -110,7 +163,6 @@ export const buildRhymeOverlays = (
     const group = lineToGroup.get(i);
     if (!group) return null;
 
-    // Peer lines = all other members of the same group
     const peerLines = group.lineIndices
       .filter(idx => idx !== i)
       .map(idx => lines[idx]!)
@@ -119,27 +171,27 @@ export const buildRhymeOverlays = (
     const split = splitRhymingSuffix(line, peerLines, langCode);
     if (!split) return null;
 
-    // Resolve position from segmentation metadata
-    // (doLinesRhymeGraphemic already ran segmentation; we derive position
-    // from the split result — if rhyme === whole line it's likely enjambed)
-    const position: RhymeOverlaySegment['position'] =
-      split.before.trim() === '' ? 'enjambed' : 'end';
+    // FIX: use Step-0 to derive position reliably
+    const { position } = segmentVerseToRhymingUnit(line, langCode);
 
     return { before: split.before, rhyme: split.rhyme, position };
   });
 };
 
+// ─── buildRhymeScheme ─────────────────────────────────────────────────────────
+
 /**
- * Derive a letter-based rhyme scheme string from groups and line count.
- * Returns null when fewer than 2 rhyming groups are present.
+ * Derive a letter-based rhyme scheme string.
  *
- * @param lineCount Total lines in the section
- * @param groups    RhymeGroup[] for the section
+ * FIX: non-rhyming positions use 'X' placeholder (not '') so the scheme string
+ * length equals lineCount and per-line indices stay aligned.
+ * Returns null when fewer than 2 distinct rhyming letters exist.
  */
 export const buildRhymeScheme = (lineCount: number, groups: RhymeGroup[]): string | null => {
   if (groups.length < 1) return null;
 
-  const letters = new Array<string>(lineCount).fill('');
+  // 'X' = non-rhyming placeholder (positionally stable)
+  const letters = new Array<string>(lineCount).fill('X');
   const alphabet = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ';
   let nextLetter = 0;
 
@@ -151,36 +203,215 @@ export const buildRhymeScheme = (lineCount: number, groups: RhymeGroup[]): strin
     }
   }
 
-  const scheme = letters.join('');
-  // A scheme with fewer than 2 distinct non-empty letters is not meaningful
-  const distinctLetters = new Set(letters.filter(Boolean));
-  return distinctLetters.size >= 2 ? scheme : null;
+  const distinctRhyming = new Set(letters.filter(l => l !== 'X'));
+  return distinctRhyming.size >= 2 ? letters.join('') : null;
 };
+
+// ─── analyseSection / analyseSong ────────────────────────────────────────────
 
 /**
  * Full analysis for a single section.
  *
- * @param section  Section object from the song data model
- * @param langCode ISO 639 code for the song's primary language
+ * FIX: meta lines and empty lines are filtered out before analysis. The overlay
+ * array is re-mapped to the full section.lines length, with nulls for meta/empty
+ * positions, so callers can index it by the original line index.
  */
 export const analyseSection = (
   section: Section,
   langCode?: string,
 ): SectionRhymeAnalysis => {
-  const lines = (section.lines ?? []).map(l => l.text ?? '');
-  const groups = buildRhymeGroups(lines, langCode);
-  const overlays = buildRhymeOverlays(lines, groups, langCode);
-  const scheme = buildRhymeScheme(lines.length, groups);
+  const allLines = section.lines ?? [];
+
+  // Collect lyric-only lines with their original indices
+  const lyricEntries: { idx: number; text: string }[] = [];
+  allLines.forEach((l, idx) => {
+    if (!l.isMeta && l.text?.trim()) lyricEntries.push({ idx, text: l.text });
+  });
+
+  const lyricTexts = lyricEntries.map(e => e.text);
+  const groups = buildRhymeGroups(lyricTexts, langCode);
+  const lyricOverlays = buildRhymeOverlays(lyricTexts, groups, langCode);
+  const scheme = buildRhymeScheme(lyricTexts.length, groups);
+
+  // Re-map overlays to full section length (null for meta / empty positions)
+  const overlays: (RhymeOverlaySegment | null)[] = new Array(allLines.length).fill(null);
+  lyricEntries.forEach(({ idx }, lyricIdx) => {
+    overlays[idx] = lyricOverlays[lyricIdx] ?? null;
+  });
+
   return { groups, overlays, scheme };
 };
 
-/**
- * Full analysis for an entire song (all sections).
- *
- * @param sections Song sections
- * @param langCode ISO 639 code for the song's primary language
- */
 export const analyseSong = (
   sections: Section[],
   langCode?: string,
 ): SectionRhymeAnalysis[] => sections.map(section => analyseSection(section, langCode));
+
+// ─── analyzeSongRhymes (original async API — preserved for consumers) ─────────
+
+/**
+ * Builds lightweight, local rhyme diagnostics for each song section.
+ * This is the primary async entry point used by useSongAnalysisEngine.
+ */
+export const analyzeSongRhymes = async (
+  song: Section[],
+  detectCrossSectionBoundary = false,
+): Promise<LocalRhymeSectionAnalysis[]> => {
+  const results = await Promise.all(song.map(async (section, sectionIndex) => {
+    const rawLyricLines = section.lines
+      .filter(line => !line.isMeta)
+      .map(line => line.text.trim())
+      .filter(Boolean);
+
+    const sectionLangCode = languageNameToCode(section.language ?? '');
+
+    const { getAlgoFamily } = await import('../constants/langFamilyMap');
+    const family = sectionLangCode ? getAlgoFamily(sectionLangCode) : undefined;
+    const isProxied = family ? !NATIVE_G2P_FAMILIES.has(family) : false;
+
+    const segmented = rawLyricLines.map(rawLine => {
+      const resolved = sectionLangCode
+        ? detectLineLang(rawLine, sectionLangCode)
+        : { text: rawLine, langCode: sectionLangCode ?? '' };
+      const segment = segmentVerseToRhymingUnit(resolved.text, resolved.langCode || undefined);
+      return {
+        rawText: resolved.text,
+        langCode: resolved.langCode,
+        rhymingUnit: segment.rhymingUnit,
+        position: segment.position,
+      };
+    });
+
+    const lyricLines = segmented.map(s => s.rawText);
+    const graphemicScheme = detectRhymeSchemeLocally(lyricLines, sectionLangCode);
+
+    if (!sectionLangCode || lyricLines.length < 2) {
+      return {
+        sectionId: section.id,
+        sectionName: section.name,
+        ...(sectionLangCode !== undefined ? { langCode: sectionLangCode } : {}),
+        detectedScheme: graphemicScheme,
+        mode: 'graphemic' as const,
+        isProxied,
+        pairs: [] as LocalRhymePairAnalysis[],
+        _sectionIndex: sectionIndex,
+        _lyricLines: lyricLines,
+        _segmented: segmented,
+      };
+    }
+
+    try {
+      const pairs: LocalRhymePairAnalysis[] = [];
+
+      for (let firstIndex = 0; firstIndex < segmented.length; firstIndex++) {
+        for (let secondIndex = firstIndex + 1; secondIndex < segmented.length; secondIndex++) {
+          const first = segmented[firstIndex]!;
+          const second = segmented[secondIndex]!;
+          const isCrossFamily = first.langCode !== second.langCode;
+          const inputA = first.rhymingUnit || first.rawText;
+          const inputB = second.rhymingUnit || second.rawText;
+
+          const similarity = await compareTextsWithIPA(
+            inputA,
+            inputB,
+            first.langCode,
+            isCrossFamily ? { langCode2: second.langCode } : undefined,
+          );
+
+          pairs.push({
+            lineIndexes: [firstIndex, secondIndex],
+            lines: [first.rawText, second.rawText],
+            quality: similarity.quality,
+            confidenceScore: toPairConfidenceScore(similarity as { score?: number; isApproximated?: boolean }),
+            usedIpa: true,
+            isApproximated: Boolean((similarity as { isApproximated?: boolean }).isApproximated),
+            rhymePosition: first.position,
+            ...(isCrossFamily && { crossFamily: true }),
+          });
+        }
+      }
+
+      const ipaScheme = detectRhymeSchemeFromIPAPairs(lyricLines.length, pairs);
+
+      return {
+        sectionId: section.id,
+        sectionName: section.name,
+        ...(sectionLangCode !== undefined ? { langCode: sectionLangCode } : {}),
+        detectedScheme: ipaScheme ?? graphemicScheme,
+        mode: 'ipa' as const,
+        isProxied,
+        pairs,
+        _sectionIndex: sectionIndex,
+        _lyricLines: lyricLines,
+        _segmented: segmented,
+      };
+    } catch {
+      return {
+        sectionId: section.id,
+        sectionName: section.name,
+        ...(sectionLangCode !== undefined ? { langCode: sectionLangCode } : {}),
+        detectedScheme: graphemicScheme,
+        mode: 'graphemic' as const,
+        isProxied,
+        pairs: [] as LocalRhymePairAnalysis[],
+        _sectionIndex: sectionIndex,
+        _lyricLines: lyricLines,
+        _segmented: segmented,
+      };
+    }
+  }));
+
+  if (detectCrossSectionBoundary && results.length >= 2) {
+    for (let i = 0; i < results.length - 1; i++) {
+      const current = results[i]!;
+      const next = results[i + 1]!;
+      const lastLine = current._lyricLines[current._lyricLines.length - 1];
+      const firstLine = next._lyricLines[0];
+      if (!lastLine || !firstLine) continue;
+      const langCode = current.langCode;
+      try {
+        if (langCode) {
+          const lastSeg = current._segmented[current._segmented.length - 1];
+          const firstSeg = next._segmented?.[0];
+          const isCrossFamily = lastSeg && firstSeg && lastSeg.langCode !== firstSeg.langCode;
+          const inputA = lastSeg?.rhymingUnit || lastLine;
+          const inputB = firstSeg?.rhymingUnit || firstLine;
+          const langA = lastSeg?.langCode || langCode;
+          const langB = firstSeg?.langCode || next.langCode || langCode;
+          const similarity = await compareTextsWithIPA(
+            inputA, inputB, langA,
+            isCrossFamily ? { langCode2: langB } : undefined,
+          );
+          current.pairs.push({
+            lineIndexes: [current._lyricLines.length - 1, -1],
+            lines: [lastLine, firstLine],
+            quality: similarity.quality,
+            confidenceScore: toPairConfidenceScore(similarity as { score?: number; isApproximated?: boolean }),
+            usedIpa: true,
+            isApproximated: Boolean((similarity as { isApproximated?: boolean }).isApproximated),
+            crossSection: true,
+            rhymePosition: lastSeg?.position ?? 'end',
+            ...(isCrossFamily && { crossFamily: true }),
+          });
+        } else {
+          if (doLinesRhymeGraphemic(lastLine, firstLine)) {
+            current.pairs.push({
+              lineIndexes: [current._lyricLines.length - 1, -1],
+              lines: [lastLine, firstLine],
+              quality: 'graphemic',
+              confidenceScore: 70,
+              usedIpa: false,
+              isApproximated: true,
+              crossSection: true,
+              rhymePosition: 'end',
+            });
+          }
+        }
+      } catch {
+        // best-effort
+      }
+    }
+  }
+
+  return results.map(({ _sectionIndex: _si, _lyricLines: _ll, _segmented: _sg, ...rest }) => rest);
+};


### PR DESCRIPTION
… code-switching

- rhymeDetection: splitRhymingSuffix + doLinesRhymeGraphemic now call segmentVerseToRhymingUnit (Step-0) before graphemic matching so internal/enjambed/agglutinative lines are handled upstream of scoring
- rhymeDetection: ENJAMBMENT_CONNECTORS extended with KWA/BNT/CRV/CRE connectors (Yoruba àti, Swahili na/ya/wa, Dioula ni/ka, Nouchi pis/avec)
- songRhymeAnalysis: langCode threaded through analyseSection, buildRhymeGroups, getRhymeOverlay — consumers receive family-aware graphemic matching instead of always falling back to ALGO-ROM rules
- ipaPipeline: compareMultipleTexts wired to compareTextsWithIPA so the pairwise matrix respects tone weights and cross-family scoring