### PR TITLE
fix(rhyme): avoid French mute-e over-grouping in graphemic schemes

### DIFF
--- a/src/utils/rhymeDetection.ts
+++ b/src/utils/rhymeDetection.ts
@@ -182,8 +182,17 @@ const getLongestCommonSuffix = (a: string, b: string): string => {
  * exact one-vowel matches for short endings such as "zéro"/"ego" so we do not
  * discard valid monosyllabic vowel rhymes.
  */
-const isSharedRhymeStrongEnough = (suffix: string, exactMatch: boolean): boolean =>
-  suffix.length >= 2 || (exactMatch && suffix.length === 1 && isVowel(suffix));
+const isSharedRhymeStrongEnough = (suffix: string, exactMatch: boolean, langCode?: string, a?: string, b?: string): boolean => {
+  if (suffix.length >= 2) return true;
+
+  // For Romance languages (incl. default), disallow 1-letter matches on mute 'e'
+  // to avoid spurious rhymes like "espace"/"visage" that only share final -e.
+  const family = langCode ? getAlgoFamily(langCode) : undefined;
+  const isRomance = !family || family === 'ALGO-ROM';
+  if (isRomance) return false;
+
+  return exactMatch && suffix.length === 1 && isVowel(suffix);
+};
 
 /**
  * Compare every vowel-group-based candidate suffix from two lines and keep the
@@ -203,7 +212,7 @@ const findBestSharedRhymeSuffix = (a: string, b: string, langCode?: string): str
       const sharedSuffix = exactMatch
         ? aCandidate.normalizedSuffix
         : getLongestCommonSuffix(aCandidate.normalizedSuffix, bCandidate.normalizedSuffix);
-      if (!isSharedRhymeStrongEnough(sharedSuffix, exactMatch)) continue;
+      if (!isSharedRhymeStrongEnough(sharedSuffix, exactMatch, langCode, aCandidate.normalizedSuffix, bCandidate.normalizedSuffix)) continue;
       if (sharedSuffix.length > bestMatch.length) bestMatch = sharedSuffix;
     }
   }

--- a/src/utils/songRhymeAnalysis.test.ts
+++ b/src/utils/songRhymeAnalysis.test.ts
@@ -299,4 +299,21 @@ describe('detectRhymeSchemeLocally — French schemes', () => {
     const scheme = detectRhymeSchemeLocally(lines, 'fr');
     expect(scheme).toBe('AABB');
   });
+
+  it('does not over-group French lines that only share a final mute -e', () => {
+    const lines = [
+      'Un instant éternel, venu d\'un autre espace,',
+      'Mon âme a senti cette étreinte qui passe,',
+      'Avec un inconnu, sans mots et sans visage,',
+      'Un secret partagé, au-delà de l\'âge.',
+    ];
+
+    const scheme = detectRhymeSchemeLocally(lines, 'fr');
+    // Expect two distinct rhyme families: espace/passe vs visage/âge
+    expect(scheme).toBe('AABB');
+  });
+
+  it('treats connaissance/effervescence as a valid Romance rhyme pair', () => {
+    expect(doLinesRhymeGraphemic('Sa forme défiait toute ma connaissance,', 'Une danse de lueurs, une douce effervescence', 'fr')).toBe(true);
+  });
 });


### PR DESCRIPTION
### Problem
French graphemic rhyme detection and underlining were over-grouping lines that only shared a final mute `-e`, which then leaked into AABB scheme detection and produced visually misleading rhyme overlays in the Lyricist editor.

### Changes
- **rhymeDetection.ts**
  - Tighten `isSharedRhymeStrongEnough` so that for Romance languages (ALGO-ROM and default), single-character vowel matches are no longer accepted as valid rhyme nuclei. This avoids spurious rhymes such as `espace` / `visage` that only share a final `-e`, while preserving existing behaviour for non-Romance families.
  - Keep the previous behaviour for non-Romance families so monosyllabic vowel rhymes like `zéro` / `ego` (and similar patterns in other scripts) continue to be recognised.
- **songRhymeAnalysis.test.ts**
  - Add a regression test `does not over-group French lines that only share a final mute -e` using the stanza:
    - `Un instant éternel, venu d'un autre espace,`
    - `Mon âme a senti cette étreinte qui passe,`
    - `Avec un inconnu, sans mots et sans visage,`
    - `Un secret partagé, au-delà de l'âge.`
    Expectation: `detectRhymeSchemeLocally(lines, 'fr') === 'AABB'`, i.e. `espace/passe` vs `visage/âge` in two distinct families.
  - Add a positive regression test for the Romance family: `doLinesRhymeGraphemic` must return `true` for `connaissance` / `effervescence` in French, ensuring we still accept rich Romance rhymes ending in `-ance` / `-ence`.

### Rationale
- In French, a bare final mute `-e` is not sufficient to define a rhyme family; the nucleus must include at least the stressed vowel-plus-consonant pattern before the schwa. Treating a single-character shared vowel as a valid rhyme nucleus at graphemic level led to false-positive rhyme detection and confusing underlines in Vibe.
- We restrict the one-letter exact-match shortcut to non-Romance families, where orthography and syllable structure differ and where monosyllabic vowel-only words are more common.

### Impact
- French (and more broadly ALGO-ROM) graphemic fallback now:
  - Keeps clear separation between `espace/passe` and `visage/âge` families in both underlines and scheme labels.
  - Continues to accept structurally rich Romance rhymes like `connaissance` / `effervescence`.
- Non-Romance languages remain unchanged.

### Notes
- This PR only touches the graphemic layer; IPA-based scoring is unaffected and still the default for supported languages.
- Tests added in `songRhymeAnalysis.test.ts` guard against regressions on both the negative (mute `-e` only) and positive (`-ance`/`-ence`) French cases.
