### PR TITLE
ci: add tsc --noEmit gate + automated version bump workflow (S3-A + S3-B)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,8 +23,11 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Typecheck
+      - name: Lint
         run: npm run lint
+
+      - name: Typecheck
+        run: npx tsc --noEmit
 
       - name: Build
         run: npm run build

--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -1,0 +1,57 @@
+name: Version Bump
+
+on:
+  push:
+    branches:
+      - main
+    paths-ignore:
+      - '.github/workflows/**'
+
+jobs:
+  bump:
+    runs-on: ubuntu-latest
+    if: "!contains(github.event.head_commit.message, '[skip bump]')"
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          fetch-depth: 0
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Bump sub-minor-minor version
+        id: bump
+        run: |
+          CURRENT=$(node -p "require('./package.json').version")
+          echo "Current version: $CURRENT"
+          IFS='.' read -ra PARTS <<< "$CURRENT"
+          MAJOR=${PARTS[0]}
+          MINOR=${PARTS[1]:-0}
+          PATCH=${PARTS[2]:-0}
+          BUILD=${PARTS[3]:-0}
+          if [ ${#PARTS[@]} -eq 4 ]; then
+            NEW_VERSION="$MAJOR.$MINOR.$PATCH.$((BUILD + 1))"
+          else
+            NEW_VERSION="$MAJOR.$MINOR.$((PATCH + 1))"
+          fi
+          echo "New version: $NEW_VERSION"
+          echo "new_version=$NEW_VERSION" >> $GITHUB_OUTPUT
+          node -e "
+            const fs = require('fs');
+            const pkg = JSON.parse(fs.readFileSync('package.json', 'utf8'));
+            pkg.version = '$NEW_VERSION';
+            fs.writeFileSync('package.json', JSON.stringify(pkg, null, 2) + '\\n');
+          "
+
+      - name: Commit and push
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add package.json
+          git commit -m "chore: bump version to ${{ steps.bump.outputs.new_version }} [skip bump]"
+          git push

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vibe",
-  "version": "1.32.0.67",
+  "version": "1.32.0.68",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## Changements

### S3-B — `ci.yml` : gate `tsc --noEmit`

`npm run lint` = ESLint only. `npm run build` = `tsc && vite build` (compile + emit). Ajout d'un step **Typecheck** dédié entre Lint et Build pour fail-fast sur les erreurs de types sans attendre le build complet.

```
Lint → Typecheck (tsc --noEmit) → Build
```

### S3-A — `version-bump.yml` : nouveau workflow

Déclenché sur push `main`, sauf :
- commits taggés `[skip bump]` (anti-boucle infinie)
- PRs ciblant uniquement `.github/workflows/`

Détecte automatiquement le format 4-segments (`X.Y.Z.W`) et incrémente le dernier. Commit signé `github-actions[bot]`.

### `package.json`
`1.32.0.67` → `1.32.0.68`

## Après merge
Chaque merge sur `main` incrémentera automatiquement la version — les bumps manuels Copilot dans les PRs ne sont plus nécessaires.