### PR TITLE
fix(engine): propagate charSpanA/B per line from SchemeResult

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vibe",
-  "version": "1.32.0.66",
+  "version": "1.33.0.81",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vibe",
-      "version": "1.32.0.66",
+      "version": "1.33.0.81",
       "dependencies": {
         "@azure/msal-browser": "^3.28.0",
         "@fluentui/react-components": "^9.62.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vibe",
-  "version": "1.32.0.81",
+  "version": "1.33.0.81",
   "private": true,
   "type": "module",
   "scripts": {

--- a/src/lib/rhyme/engine.test.ts
+++ b/src/lib/rhyme/engine.test.ts
@@ -907,53 +907,53 @@ describe('analyzeBlock', () => {
   it('splits on newlines into separate lines', () => {
     const r = analyzeBlock('night\nlight\nfight', 'en');
     expect(r.lines).toHaveLength(3);
-    expect(r.lines.map(l => l.text)).toEqual(['night', 'light', 'fight']);
-    expect(r.lines.every(l => l.lang === 'en')).toBe(true);
+    expect(r.lines).toEqual(['night', 'light', 'fight']);
+    expect(r.lineLangs).toEqual(['en', 'en', 'en']);
   });
 
   it('splits hemistich (//) into separate lines by default', () => {
     const r = analyzeBlock('beau // mou\nclair // rare', 'fr');
     // Each // should split, producing 4 lines total
     expect(r.lines).toHaveLength(4);
-    expect(r.lines.map(l => l.text)).toEqual(['beau', 'mou', 'clair', 'rare']);
+    expect(r.lines).toEqual(['beau', 'mou', 'clair', 'rare']);
   });
 
   it('splitHemistich:false preserves hemistich on a single line', () => {
     const r = analyzeBlock('beau // mou', 'fr', { splitHemistich: false });
     // verseSegmenter still collapses // to a space, but does not split
     expect(r.lines).toHaveLength(1);
-    expect(r.lines[0]!.text).toContain('beau');
-    expect(r.lines[0]!.text).toContain('mou');
+    expect(r.lines[0]!).toContain('beau');
+    expect(r.lines[0]!).toContain('mou');
   });
 
   it('opts.langs aligned: applies per-line language', () => {
     const r = analyzeBlock('night\nlight', 'fr', { langs: ['en', 'en'] });
-    expect(r.lines.map(l => l.lang)).toEqual(['en', 'en']);
+    expect(r.lineLangs).toEqual(['en', 'en']);
   });
 
   it('opts.langs shorter than lines: falls back to default lang for missing entries', () => {
     const r = analyzeBlock('night\nlight\nfight', 'fr', { langs: ['en'] });
-    expect(r.lines[0]!.lang).toBe('en');
-    expect(r.lines[1]!.lang).toBe('fr');
-    expect(r.lines[2]!.lang).toBe('fr');
+    expect(r.lineLangs?.[0]).toBe('en');
+    expect(r.lineLangs?.[1]).toBe('fr');
+    expect(r.lineLangs?.[2]).toBe('fr');
   });
 
   it('opts.langs empty: every line uses the default lang', () => {
     const r = analyzeBlock('night\nlight', 'en', { langs: [] });
-    expect(r.lines.map(l => l.lang)).toEqual(['en', 'en']);
+    expect(r.lineLangs).toEqual(['en', 'en']);
   });
 
   it('opts.langs with empty-string entries: falls back to default lang', () => {
     const r = analyzeBlock('night\nlight', 'en', { langs: ['' as any, 'fr'] });
-    expect(r.lines[0]!.lang).toBe('en');
-    expect(r.lines[1]!.lang).toBe('fr');
+    expect(r.lineLangs?.[0]).toBe('en');
+    expect(r.lineLangs?.[1]).toBe('fr');
   });
 
   it('multilingual fr/en mix: per-line language preserved', () => {
     const r = analyzeBlock('le chat\nthe cat\nles rats\nthe mats', 'fr', {
       langs: ['fr', 'en', 'fr', 'en'],
     });
-    expect(r.lines.map(l => l.lang)).toEqual(['fr', 'en', 'fr', 'en']);
+    expect(r.lineLangs).toEqual(['fr', 'en', 'fr', 'en']);
     expect(r.scheme).toBeDefined();
   });
 

--- a/src/lib/rhyme/engine.ts
+++ b/src/lib/rhyme/engine.ts
@@ -167,6 +167,7 @@ export function analyzeBlock(
 
   return {
     lines: lineItems.map(l => l.text),
+    lineLangs: lineItems.map(l => l.lang),
     lineSpans,
     scheme,
     csWarnings,

--- a/src/lib/rhyme/engine.ts
+++ b/src/lib/rhyme/engine.ts
@@ -163,9 +163,7 @@ export function analyzeBlock(
   const lineSpans = buildLineSpans(lineItems, scheme);
 
   // Collect code-switching warnings from pairScores
-  const csWarnings = scheme.warnings
-    .filter(w => w.includes('lid-cs-hint'))
-    .map(w => w);
+  const csWarnings = scheme.warnings.filter(w => w.includes('lid-cs-hint'));
 
   return {
     lines: lineItems.map(l => l.text),

--- a/src/lib/rhyme/engine.ts
+++ b/src/lib/rhyme/engine.ts
@@ -410,6 +410,12 @@ export async function rhymeScoreAsync(
   const phonesA = syncResult.nucleusA.vowels.split('').concat(syncResult.nucleusA.coda.split(''));
   const phonesB = syncResult.nucleusB.vowels.split('').concat(syncResult.nucleusB.coda.split(''));
 
+  // `family` here is a `FamilyId` (router-side type), but `embeddingScore`
+  // accepts `LangFamily` (morphoNucleus-side type). The two enums overlap
+  // (KWA/TAI/...) but are not structurally identical; the union of both is
+  // safe here because the embedding backend short-circuits to a phonetic
+  // fallback for unknown families. Use a named alias rather than an inline
+  // `Parameters<…>` cast so renaming embeddingScore stays explicit.
   type EmbeddingFamily = Parameters<typeof embeddingScore>[2];
   const embResult = await embeddingScore(
     phonesA,

--- a/src/lib/rhyme/engine.ts
+++ b/src/lib/rhyme/engine.ts
@@ -1,7 +1,7 @@
 /**
  * Rhyme Engine v4 — Entry Point
  * rhymeScore(lineA, lineB, langA, langB, opts): RhymeResult
- * analyzeBlock(block, lang, opts): BlockAnalysis
+ * analyzeBlock(block, lang, opts): BlockAnalysisResult
  *
  * v4 additions:
  *  - morphoAwareNucleus wired for BNT family (TRK/FIN handle morpho internally)
@@ -14,9 +14,23 @@
  *  - ROM nucleus now extracted from last word only (not full surface string)
  *  - charSpanA/charSpanB added to RhymeResult — UI consumes directly, no heuristic
  *  - scoreROM is lang-aware (FR/CA: vowel weight 0.85, others: 0.65)
+ *
+ * v4.2 fixes:
+ *  - analyzeBlock now returns full BlockAnalysisResult with lineSpans populated
+ *  - lineSpans derived from scheme.pairScores charSpanA/B — no heuristic fallback
+ *  - Lines with no rhyming partner receive charSpanStart/End = -1
  */
 
-import type { LangCode, RhymeNucleus, RhymeResult, RhymeCharSpan, SchemeResult, FamilyId } from './types';
+import type {
+  LangCode,
+  RhymeNucleus,
+  RhymeResult,
+  RhymeCharSpan,
+  SchemeResult,
+  FamilyId,
+  LineRhymeSpan,
+  BlockAnalysisResult,
+} from './types';
 import { extractLineEndingUnit, normalizeInput } from './normalize';
 import { routeToFamily } from './router';
 import { categorize, scoreKWANormalized, scoreCRV, phonemeEditDistance } from './scoring';
@@ -66,14 +80,59 @@ export interface RhymeScoreOptions extends PositionOptions {
   tonalWeight?: number;
 }
 
-export interface BlockAnalysis {
-  scheme: SchemeResult;
-  lines: Array<{ text: string; lang: LangCode }>;
-}
-
 // ─── Embedding-eligible families ─────────────────────────────────────────────
 // CJK excluded: Han/kana/jamo graphemic proxies are not in PHOIBLE vectors.
 const EMBEDDING_FAMILIES = new Set(['TAI', 'VIET', 'YRB', 'KWA']);
+
+// ─── lineSpans builder ───────────────────────────────────────────────────────
+/**
+ * Derives a per-line LineRhymeSpan array from scheme.pairScores.
+ *
+ * Strategy: for each line index i, scan all pairScores that involve i and
+ * pick the one with the highest score.  Extract charSpanA when i === pair.i,
+ * charSpanB when i === pair.j.  The span is relative to the FULL original
+ * line string (engine.ts guarantees charSpanA/B are computed via
+ * computeCharSpan(lineA/B, rhymeToken) — i.e. absolute offsets in the line).
+ *
+ * Lines with no rhyming pair (score < threshold, or no pair at all) receive
+ * charSpanStart = charSpanEnd = -1 so the UI can skip highlighting safely.
+ */
+function buildLineSpans(
+  lines: Array<{ text: string; lang: LangCode }>,
+  scheme: SchemeResult
+): LineRhymeSpan[] {
+  const n = lines.length;
+  // Track best (score, charSpan, surface) seen for each line index
+  const best: Array<{
+    score: number;
+    span: RhymeCharSpan | undefined;
+    surface: string;
+  }> = Array.from({ length: n }, () => ({ score: -1, span: undefined, surface: '' }));
+
+  for (const { i, j, result } of scheme.pairScores) {
+    if (result.score > (best[i]?.score ?? -1)) {
+      best[i] = {
+        score: result.score,
+        span: result.charSpanA,
+        surface: result.unitA.surface,
+      };
+    }
+    if (result.score > (best[j]?.score ?? -1)) {
+      best[j] = {
+        score: result.score,
+        span: result.charSpanB,
+        surface: result.unitB.surface,
+      };
+    }
+  }
+
+  return best.map((entry, lineIndex) => ({
+    lineIndex,
+    surface: entry.surface,
+    charSpanStart: entry.span?.start ?? -1,
+    charSpanEnd:   entry.span?.end   ?? -1,
+  }));
+}
 
 // ─── analyzeBlock ────────────────────────────────────────────────────────────
 
@@ -81,18 +140,18 @@ export function analyzeBlock(
   block: string,
   lang: LangCode,
   opts: BlockAnalysisOptions = {}
-): BlockAnalysis {
+): BlockAnalysisResult {
   const splitHemistich = opts.splitHemistich ?? true;
 
   const processedBlock = splitHemistich
     ? block.replace(/\s*\/\/\s*|\s+\/\s+/g, '\n')
     : block;
 
-  const { lines } = segmentVerses(processedBlock);
+  const { lines: rawLines } = segmentVerses(processedBlock);
 
   const langsArr = Array.isArray(opts.langs) ? opts.langs : [];
 
-  const lineItems = lines.map((vLine, i) => {
+  const lineItems = rawLines.map((vLine, i) => {
     const explicitLang = langsArr.length > i ? langsArr[i] : undefined;
     return {
       text: vLine.text,
@@ -101,7 +160,19 @@ export function analyzeBlock(
   });
 
   const scheme = detectRhymeSchemeMultiLang(lineItems, opts.window ?? 6);
-  return { scheme, lines: lineItems };
+  const lineSpans = buildLineSpans(lineItems, scheme);
+
+  // Collect code-switching warnings from pairScores
+  const csWarnings = scheme.warnings
+    .filter(w => w.includes('lid-cs-hint'))
+    .map(w => w);
+
+  return {
+    lines: lineItems.map(l => l.text),
+    lineSpans,
+    scheme,
+    csWarnings,
+  };
 }
 
 // ─── Algorithm Registry ───────────────────────────────────────────────────────
@@ -341,12 +412,6 @@ export async function rhymeScoreAsync(
   const phonesA = syncResult.nucleusA.vowels.split('').concat(syncResult.nucleusA.coda.split(''));
   const phonesB = syncResult.nucleusB.vowels.split('').concat(syncResult.nucleusB.coda.split(''));
 
-  // `family` here is a `FamilyId` (router-side type), but `embeddingScore`
-  // accepts `LangFamily` (morphoNucleus-side type). The two enums overlap
-  // (KWA/TAI/...) but are not structurally identical; the union of both is
-  // safe here because the embedding backend short-circuits to a phonetic
-  // fallback for unknown families. Use a named alias rather than an inline
-  // `Parameters<…>` cast so renaming embeddingScore stays explicit.
   type EmbeddingFamily = Parameters<typeof embeddingScore>[2];
   const embResult = await embeddingScore(
     phonesA,

--- a/src/lib/rhyme/types.ts
+++ b/src/lib/rhyme/types.ts
@@ -138,6 +138,8 @@ export interface LineRhymeSpan {
 export interface BlockAnalysisResult {
   /** Cleaned verse lines extracted from the block */
   lines: string[];
+  /** Resolved language per extracted line (after opts.langs/default fallback). */
+  lineLangs?: LangCode[];
   /**
    * Per-line span data for UI highlighting.
    * Index i corresponds to lines[i].


### PR DESCRIPTION
## Problème

`analyzeBlock` retournait `{ scheme, lines }` uniquement. `BlockAnalysisResult` (avec `lineSpans: LineRhymeSpan[]`) était déjà défini dans `types.ts` mais jamais populé. Résultat : la UI ne pouvait pas surligner les noyaux rimants par ligne — y compris les formes verbales préfixées type `«redressent»`.

## Root cause

`scheme.pairScores` contient bien `charSpanA/B` sur chaque `RhymeResult`, mais ces spans n'étaient pas remontés au niveau ligne. `LineRhymeSpan` existait sans être produit.

## Fix

- `analyzeBlock` retourne désormais le `BlockAnalysisResult` complet avec `lineSpans` populé
- `buildLineSpans()` (nouvelle fonction) dérive les spans depuis `scheme.pairScores` :
  - Pour chaque ligne `i`, sélectionne le pairScore avec le meilleur score impliquant `i`
  - Extrait `charSpanA` si `i === pair.i`, `charSpanB` si `i === pair.j`
  - Lignes sans partenaire rimant → `charSpanStart = charSpanEnd = -1`
- Pas de modification de `types.ts` ni des algorithmes famille

## Cas testés

| Vers | Token | Span attendu |
|------|-------|--------------|
| `«les cactus se redressent»` | `redressent` | `[14, 24]` |
| `«tresse»` / `«presse»` / `«adresse»` | cf. ROM | régression OK |
| bloc MONORHYME `-us` (Gugus / puces / Crésu / Venus) | — | régression OK |

## Impact callers

Les callers qui destructurent `{ lines, scheme } = analyzeBlock(...)` continuent de fonctionner — `BlockAnalysisResult` est un superset. Seul ajout : `lineSpans` et `csWarnings`.