### PR TITLE
fix(cloud-providers): blob.text(), event.source guard, MSAL catch logs (P1–P4)

### DIFF
--- a/src/services/cloudProviders/DropboxStrategy.ts
+++ b/src/services/cloudProviders/DropboxStrategy.ts
@@ -19,15 +19,6 @@ function isAudioFile(name: string): boolean {
   return AUDIO_EXTENSIONS.some(ext => name.toLowerCase().endsWith(ext));
 }
 
-async function readBlobAsText(blob: Blob): Promise<string> {
-  return new Promise((resolve, reject) => {
-    const reader = new FileReader();
-    reader.onload = () => resolve(reader.result as string);
-    reader.onerror = () => reject(reader.error);
-    reader.readAsText(blob);
-  });
-}
-
 async function pickDropbox(mode: PickMode, signal?: AbortSignal): Promise<CloudFile | null> {
   if (!DROPBOX_APP_KEY) return null;
   if (mode === 'player') throw new Error('Dropbox folder crawl not yet supported');
@@ -65,8 +56,8 @@ async function pickDropbox(mode: PickMode, signal?: AbortSignal): Promise<CloudF
           if (!file) { resolve(null); return; }
           if (!isLyricsFile(file.name)) { resolve(null); return; }
           const resp = await fetch(file.link);
-          const blob = await resp.blob();
-          const content = await readBlobAsText(blob);
+          // P1: blob.text() remplace FileReader callback — même sémantique, ES2020.
+          const content = await resp.blob().then(b => b.text());
           resolve({ name: file.name, content });
         } catch (err) { reject(err); }
       },

--- a/src/services/cloudProviders/OneDriveStrategy.ts
+++ b/src/services/cloudProviders/OneDriveStrategy.ts
@@ -33,15 +33,6 @@ function isAudioFile(name: string): boolean {
   return AUDIO_EXTENSIONS.some(ext => name.toLowerCase().endsWith(ext));
 }
 
-async function readBlobAsText(blob: Blob): Promise<string> {
-  return new Promise((resolve, reject) => {
-    const reader = new FileReader();
-    reader.onload = () => resolve(reader.result as string);
-    reader.onerror = () => reject(reader.error);
-    reader.readAsText(blob);
-  });
-}
-
 // ─── MSAL singleton (shared across personal + business instances) ─────────────
 
 let _msalApp: PublicClientApplication | null = null;
@@ -76,7 +67,9 @@ async function getMsalToken(scopes: string[]): Promise<string | null> {
     try {
       const result = await app.acquireTokenPopup({ scopes });
       return result.accessToken;
-    } catch {
+    } catch (err) {
+      // P4: log pour conserver la trace en prod — logger.warn survit hors DEV.
+      logger.warn('[OneDriveStrategy] MSAL acquireTokenPopup fallback failed:', err);
       return null;
     }
   }
@@ -203,6 +196,9 @@ async function pickOneDrive(
 
     const messageHandler = async (event: MessageEvent) => {
       if (!isAllowedOneDriveOrigin(event.origin)) return;
+      // P3: défense en profondeur — s'assurer que le message vient bien de
+      // la fenêtre picker ouverte, pas d'une autre frame OneDrive tierce.
+      if (event.source !== pickerWindow) return;
 
       const msg = event.data as {
         type?: string;
@@ -280,8 +276,8 @@ async function pickOneDrive(
         if (downloadUrl) {
           const resp = await fetch(downloadUrl);
           if (!resp.ok) throw new Error(`Download failed: ${resp.status}`);
-          const blob = await resp.blob();
-          const content = await readBlobAsText(blob);
+          // P2: blob.text() remplace FileReader callback.
+          const content = await resp.blob().then(b => b.text());
           resolve({ name: item.name, content });
         } else if (item.id) {
           const resp = await fetch(
@@ -289,8 +285,8 @@ async function pickOneDrive(
             { headers: { Authorization: `Bearer ${token}` } },
           );
           if (!resp.ok) throw new Error(`Graph download failed: ${resp.status}`);
-          const blob = await resp.blob();
-          const content = await readBlobAsText(blob);
+          // P2: blob.text() remplace FileReader callback.
+          const content = await resp.blob().then(b => b.text());
           resolve({ name: item.name, content });
         } else {
           resolve(null);

--- a/src/services/cloudStorage.ts
+++ b/src/services/cloudStorage.ts
@@ -20,6 +20,7 @@ import {
   PublicClientApplication,
   type Configuration,
 } from '@azure/msal-browser';
+import { logger } from '../utils/logger';
 
 // ─── Types publics ────────────────────────────────────────────────────────────
 
@@ -114,7 +115,9 @@ async function getMsalWriteToken(): Promise<string | null> {
     try {
       const result = await app.acquireTokenPopup({ scopes });
       return result.accessToken;
-    } catch {
+    } catch (err) {
+      // P4: log pour conserver la trace en prod — logger.warn survit hors DEV.
+      logger.warn('[cloudStorage] MSAL acquireTokenPopup fallback failed:', err);
       return null;
     }
   }


### PR DESCRIPTION
## Contexte

Suite à l'audit approfondi des strategies cloud (`DropboxStrategy`, `OneDriveStrategy`, `cloudStorage`). 4 points corrigés.

---

## Changements

### P1 — `DropboxStrategy.ts` — `blob.text()` remplace `FileReader`

```diff
- const content = await readBlobAsText(blob)
+ const content = await resp.blob().then(b => b.text())
```

`FileReader` callback inutile depuis ES2020 (`Blob.prototype.text()`). Même sémantique, code simplifié, `readBlobAsText` supprimée.

### P2 — `OneDriveStrategy.ts` — `blob.text()` (×2 call sites)

Même remplacement sur les deux branches du path lyrics : `downloadUrl` direct + fallback Graph `/content`. `readBlobAsText` supprimée.

### P3 — `OneDriveStrategy.ts` — `event.source !== pickerWindow`

```diff
+ if (event.source !== pickerWindow) return;
```

Défense en profondeur dans `messageHandler` : après le check origin, vérification que le message provient bien de la fenêtre picker ouverte et pas d'une autre frame OneDrive légitime. Sévérité faible mais bonne pratique défensive.

### P4 — `OneDriveStrategy.ts` + `cloudStorage.ts` — MSAL catch silencieux → `logger.warn`

```diff
- } catch { return null; }
+ } catch (err) { logger.warn('[...] MSAL acquireTokenPopup fallback failed:', err); return null; }
```

`logger.warn` survit en prod (cf. `logger.ts` : seul `debug`/`info` sont silencés hors DEV).

---

## Hors scope (intentionnel)

- **P5** (`GDriveStrategy` double `resolve` sur close) : bug cosmétique inobservable (Promise déjà résolue ignore les appels suivants). Reporté en backlog.
- **`GDriveStrategy`** : aucune modification — les corrections ne s'y appliquent pas.

---

## Tests

Aucune API publique modifiée. Les call sites existants sont inchangés. Vérification manuelle des 3 fichiers modifiés.